### PR TITLE
add droidmediarecorder

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -33,6 +33,7 @@ LOCAL_SRC_FILES := droidmedia.cpp \
                    droidmediaconstants.cpp \
                    droidmediacodec.cpp \
                    droidmediaconvert.cpp \
+                   droidmediarecorder.cpp \
                    allocator.cpp \
                    droidmediabuffer.cpp \
                    private.cpp

--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -448,3 +448,7 @@ int32_t droid_media_camera_get_video_color_format (DroidMediaCamera *camera)
 }
 
 };
+
+android::sp<android::Camera> droid_media_camera_get_camera (DroidMediaCamera *camera) {
+  return camera->m_camera;
+}

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -429,6 +429,13 @@ private:
   DroidMediaCodecDecoderMetaData *m_dec;
 };
 
+android::sp<android::MediaSource> droid_media_codec_create_encoder_raw(DroidMediaCodecEncoderMetaData *meta,
+							      android::sp<android::MediaSource> src)
+{
+  DroidMediaCodecBuilder builder(meta);
+  return builder.createCodec(src, NULL);
+}
+
 extern "C" {
 
 DroidMediaBufferQueue *droid_media_codec_get_buffer_queue (DroidMediaCodec *codec)

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -290,109 +290,68 @@ private:
     DroidMediaCodec *m_codec;
 };
 
-extern "C" {
+class DroidMediaCodecBuilder {
+public:
+  DroidMediaCodecBuilder(DroidMediaCodecEncoderMetaData *meta) :
+    m_enc(meta), m_dec(NULL) {}
+  DroidMediaCodecBuilder(DroidMediaCodecDecoderMetaData *meta) :
+    m_enc(NULL), m_dec(meta) {}
 
-DroidMediaBufferQueue *droid_media_codec_get_buffer_queue (DroidMediaCodec *codec)
-{
-  return codec->m_queue.get();
-}
-
-DroidMediaCodec *droid_media_codec_create(DroidMediaCodecMetaData *meta,
-                                          android::sp<android::MetaData>& md, bool is_encoder, uint32_t flags)
-{
+  android::sp<android::MediaSource> createCodec(android::sp<android::MediaSource> src,
+						android::sp<ANativeWindow> window,
+						android::sp<android::MetaData> md = NULL) {
     android::OMXClient omx;
     if (omx.connect() != android::OK) {
-        ALOGE("DroidMediaCodec: Failed to connect to OMX");
-        return NULL;
+      ALOGE("DroidMediaCodec: Failed to connect to OMX");
+      return NULL;
     }
 
-    // We will not do any validation for the flags. Stagefright should take care of that.
-    if (meta->flags & DROID_MEDIA_CODEC_SW_ONLY) {
-        flags |= android::OMXCodec::kSoftwareCodecsOnly;
+    if (md == NULL) {
+      md = buildMetaData();
     }
 
-    if (meta->flags & DROID_MEDIA_CODEC_HW_ONLY) {
-        flags |= android::OMXCodec::kHardwareCodecsOnly;
+    if (md == NULL) {
+      return NULL;
     }
 
-    android::sp<Source> src(new Source(md));
+    return android::OMXCodec::Create(omx.interface(),
+				     md,
+				     isEncoder(),
+				     src,
+				     NULL, flags(), window);
 
-    md->setCString(android::kKeyMIMEType, meta->type);
-    SET_PARAM(kKeyWidth, width);
-    SET_PARAM(kKeyHeight, height);
-    SET_PARAM(kKeyDisplayWidth, width);
-    SET_PARAM(kKeyDisplayHeight, height);
-    SET_PARAM(kKeyFrameRate, fps);
-    SET_PARAM(kKeyChannelCount, channels);
-    SET_PARAM(kKeySampleRate, sample_rate);
+  }
 
-    android::sp<DroidMediaBufferQueue> queue;
-    android::sp<ANativeWindow> window = NULL;
+  bool isEncoder() { return m_enc != NULL; }
 
-    if (is_encoder
-        || meta->flags & DROID_MEDIA_CODEC_SW_ONLY
-        || meta->flags & DROID_MEDIA_CODEC_NO_MEDIA_BUFFER) {
-        // Nothing
+  DroidMediaCodecMetaData *meta() {
+    if (m_enc) {
+      return (DroidMediaCodecMetaData *)m_enc;
+    } else if (m_dec) {
+      return (DroidMediaCodecMetaData *)m_dec;
     } else {
-        queue = new DroidMediaBufferQueue("DroidMediaCodecBufferQueue");
-	window = queue->window();
+      return NULL;
     }
+  }
 
-    android::sp<android::MediaSource> codec
-        = android::OMXCodec::Create(omx.interface(),
-                                    md,
-                                    is_encoder,
-                                    src,
-                                    NULL, flags, window);
-
-    if (codec == NULL) {
-        ALOGE("DroidMediaCodec: Failed to create codec");
-        omx.disconnect();
-        return NULL;
+  android::sp<android::MetaData> buildMetaData() {
+    if (isEncoder()) {
+      return buildMetaData(m_enc);
+    } else {
+      return buildMetaData(m_dec);
     }
+  }
 
-    DroidMediaCodec *mediaCodec = new DroidMediaCodec;
-    mediaCodec->m_codec = codec;
-    mediaCodec->m_src = src;
-    mediaCodec->m_queue = queue;
-    mediaCodec->m_window = window;
-
-    mediaCodec->m_useExternalLoop = (meta->flags & DROID_MEDIA_CODEC_USE_EXTERNAL_LOOP) ? true : false;
-
-    return mediaCodec;
-}
-
-DroidMediaCodec *droid_media_codec_create_decoder(DroidMediaCodecDecoderMetaData *meta)
-{
-    android::sp<android::MetaData> md(new android::MetaData);
-
-    if (meta->codec_data.size > 0) {
-        const char *mime = ((DroidMediaCodecMetaData *)meta)->type;
-        DroidMediaCodecMetaDataKey *key = metaDataKeys;
-        bool found = false;
-
-        while (key->mime) {
-            if (!strcmp (key->mime, mime)) {
-                md->setData(key->key, key->type, meta->codec_data.data, meta->codec_data.size);
-                found = true;
-                break;
-            }
-            ++key;
-        }
-
-        if (!found) {
-            ALOGE("DroidMediaCodec: No handler for codec data for %s", ((DroidMediaCodecMetaData *)meta)->type);
-            return NULL;
-        }
+  uint32_t flags() {
+    if (isEncoder()) {
+      return flags(m_enc);
+    } else {
+      return flags(m_dec);
     }
+  }
 
-    return droid_media_codec_create((DroidMediaCodecMetaData *)meta, md, false, 0);
-}
-
-DroidMediaCodec *droid_media_codec_create_encoder(DroidMediaCodecEncoderMetaData *meta)
-{
-    uint32_t flags = 0;
-
+private:
+  android::sp<android::MetaData> buildMetaData(DroidMediaCodecEncoderMetaData *meta) {
     android::sp<android::MetaData> md(new android::MetaData);
     SET_PARAM(kKeyMaxInputSize, max_input_size);
     SET_PARAM(kKeyBitRate, bitrate);
@@ -404,11 +363,130 @@ DroidMediaCodec *droid_media_codec_create_encoder(DroidMediaCodecEncoderMetaData
     md->setInt32(android::kKeyIFramesInterval, 2);
 
     // TODO: kKeyHFR, kKeyColorFormat
-    if (meta->meta_data) {
-        flags |= android::OMXCodec::kStoreMetaDataInVideoBuffers;
+
+    return buildMetaData((DroidMediaCodecMetaData *)meta, md);
+  }
+
+  android::sp<android::MetaData> buildMetaData(DroidMediaCodecDecoderMetaData *meta) {
+    android::sp<android::MetaData> md(new android::MetaData);
+
+    if (meta->codec_data.size > 0) {
+      const char *mime = ((DroidMediaCodecMetaData *)meta)->type;
+      DroidMediaCodecMetaDataKey *key = metaDataKeys;
+
+      while (key->mime) {
+	if (!strcmp (key->mime, mime)) {
+	  md->setData(key->key, key->type, meta->codec_data.data, meta->codec_data.size);
+	  return buildMetaData((DroidMediaCodecMetaData *)meta, md);
+	}
+	++key;
+      }
+
+      ALOGE("DroidMediaCodec: No handler for codec data for %s", ((DroidMediaCodecMetaData *)meta)->type);
+      return NULL;
     }
 
-    return droid_media_codec_create((DroidMediaCodecMetaData *)meta, md, true, flags);
+    return buildMetaData((DroidMediaCodecMetaData *)meta, md);
+  }
+
+  uint32_t flags(DroidMediaCodecEncoderMetaData *meta) {
+    return flags((DroidMediaCodecMetaData *)meta,
+		 meta->meta_data ? android::OMXCodec::kStoreMetaDataInVideoBuffers : 0);
+  }
+
+  uint32_t flags(DroidMediaCodecDecoderMetaData *meta) {
+    return flags((DroidMediaCodecMetaData *)meta, 0);
+  }
+
+  android::sp<android::MetaData> buildMetaData(DroidMediaCodecMetaData *meta,
+					       android::sp<android::MetaData> md) {
+    md->setCString(android::kKeyMIMEType, meta->type);
+    SET_PARAM(kKeyWidth, width);
+    SET_PARAM(kKeyHeight, height);
+    SET_PARAM(kKeyDisplayWidth, width);
+    SET_PARAM(kKeyDisplayHeight, height);
+    SET_PARAM(kKeyFrameRate, fps);
+    SET_PARAM(kKeyChannelCount, channels);
+    SET_PARAM(kKeySampleRate, sample_rate);
+
+    return md;
+  }
+
+  uint32_t flags(DroidMediaCodecMetaData *meta, uint32_t currentFlags) {
+    // We will not do any validation for the flags. Stagefright should take care of that.
+    if (meta->flags & DROID_MEDIA_CODEC_SW_ONLY) {
+      currentFlags |= android::OMXCodec::kSoftwareCodecsOnly;
+    }
+
+    if (meta->flags & DROID_MEDIA_CODEC_HW_ONLY) {
+      currentFlags |= android::OMXCodec::kHardwareCodecsOnly;
+    }
+
+    return currentFlags;
+  }
+
+  DroidMediaCodecEncoderMetaData *m_enc;
+  DroidMediaCodecDecoderMetaData *m_dec;
+};
+
+extern "C" {
+
+DroidMediaBufferQueue *droid_media_codec_get_buffer_queue (DroidMediaCodec *codec)
+{
+  return codec->m_queue.get();
+}
+
+DroidMediaCodec *droid_media_codec_create(DroidMediaCodecBuilder& builder)
+{
+  android::sp<android::MetaData> md(builder.buildMetaData());
+  if (md == NULL) {
+    return NULL;
+  }
+
+  android::sp<Source> src(new Source(md));
+  android::sp<DroidMediaBufferQueue> queue;
+  android::sp<ANativeWindow> window = NULL;
+  DroidMediaCodecMetaData *meta = builder.meta();
+
+  if (builder.isEncoder()
+      || meta->flags & DROID_MEDIA_CODEC_SW_ONLY
+      || meta->flags & DROID_MEDIA_CODEC_NO_MEDIA_BUFFER) {
+    // Nothing
+  } else {
+    queue = new DroidMediaBufferQueue("DroidMediaCodecBufferQueue");
+    window = queue->window();
+  }
+
+  android::sp<android::MediaSource> codec = builder.createCodec(src, window, md);
+
+  if (codec == NULL) {
+    ALOGE("DroidMediaCodec: Failed to create codec");
+    return NULL;
+  }
+
+  DroidMediaCodec *mediaCodec = new DroidMediaCodec;
+  mediaCodec->m_codec = codec;
+  mediaCodec->m_src = src;
+  mediaCodec->m_queue = queue;
+  mediaCodec->m_window = window;
+
+  mediaCodec->m_useExternalLoop = (meta->flags & DROID_MEDIA_CODEC_USE_EXTERNAL_LOOP) ? true : false;
+
+  return mediaCodec;
+}
+
+DroidMediaCodec *droid_media_codec_create_decoder(DroidMediaCodecDecoderMetaData *meta)
+{
+  DroidMediaCodecBuilder builder(meta);
+
+  return droid_media_codec_create(builder);
+}
+
+DroidMediaCodec *droid_media_codec_create_encoder(DroidMediaCodecEncoderMetaData *meta)
+{
+  DroidMediaCodecBuilder builder(meta);
+
+  return droid_media_codec_create(builder);
 }
 
 bool droid_media_codec_start(DroidMediaCodec *codec)

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -612,7 +612,7 @@ DroidMediaCodecLoopReturn droid_media_codec_loop(DroidMediaCodec *codec)
 #endif
 
     if (err != android::OK) {
-        if (err == android::ERROR_END_OF_STREAM) {
+        if (err == android::ERROR_END_OF_STREAM || err == -ENODATA) {
             ALOGE("DroidMediaCodec: Got EOS");
 
             if (codec->m_cb.signal_eos) {

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -21,6 +21,9 @@
 #include <media/stagefright/MetaData.h>
 #include "droidmediarecorder.h"
 #include "private.h"
+#if !((ANDROID_MAJOR == 4 && ANDROID_MINOR == 4) || ANDROID_MAJOR == 5)
+#include <gui/Surface.h>
+#endif
 
 struct _DroidMediaRecorder {
   _DroidMediaRecorder() :
@@ -108,8 +111,10 @@ DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidM
   recorder->m_src = android::CameraSource::CreateFromCamera(cam->remote(),
 							    cam->getRecordingProxy(), // proxy
 							    -1, // cameraId
+#if (ANDROID_MAJOR == 4 && ANDROID_MINOR == 4) || ANDROID_MAJOR == 5
 							    android::String16(), // clientName
 							    -1, // clientUid
+#endif
 							    size,  // videoSize
 							    camFrameRate, // frameRate
 							    NULL, // surface

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2016 Jolla Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Mohammed Hassan <mohammed.hassan@jolla.com>
+ */
+
+#include <utils/Condition.h>
+#include <media/stagefright/CameraSource.h>
+#include <media/stagefright/MetaData.h>
+#include "droidmediarecorder.h"
+#include "private.h"
+
+struct _DroidMediaRecorder {
+  _DroidMediaRecorder() :
+    m_cb_data(0),
+    m_running(false) {
+    memset(&m_cb, 0x0, sizeof(m_cb));
+  }
+
+  android::status_t tick() {
+    android::MediaBuffer *buffer;
+    android::status_t err = m_codec->read(&buffer);
+
+    if (buffer) {
+      DroidMediaCodecData data;
+      data.data.data = (uint8_t *)buffer->data() + buffer->range_offset();
+      data.data.size = buffer->range_length();
+      data.ts = 0;
+      data.decoding_ts = 0;
+
+      if (!buffer->meta_data()->findInt64(android::kKeyTime, &data.ts)) {
+	// I really don't know what to do here and I doubt we will reach that anyway.
+	ALOGE("DroidMediaRecorder: Received a buffer without a timestamp!");
+      } else {
+	// Convert timestamp from useconds to nseconds
+	data.ts *= 1000;
+      }
+
+      buffer->meta_data()->findInt64(android::kKeyDecodingTime, &data.decoding_ts);
+      if (data.decoding_ts) {
+	// Convert from usec to nsec.
+	data.decoding_ts *= 1000;
+      }
+
+      int32_t sync = 0;
+      data.sync = false;
+      buffer->meta_data()->findInt32(android::kKeyIsSyncFrame, &sync);
+      if (sync) {
+	data.sync = true;
+      }
+
+      int32_t codecConfig = 0;
+      data.codec_config = false;
+      if (buffer->meta_data()->findInt32(android::kKeyIsCodecConfig, &codecConfig)
+	  && codecConfig) {
+	data.codec_config = true;
+      }
+
+      m_cb.data_available (m_cb_data, &data);
+	    
+      buffer->release();
+    }
+    
+    return err;
+  }
+
+  void *run() {
+    android::status_t err = android::OK;
+    while (m_running && err == android::OK) {
+      err = tick();
+    }
+
+    return NULL;
+  }
+
+  static void *ThreadWrapper(void *that) {
+    return static_cast<DroidMediaRecorder *>(that)->run();
+  }
+
+  DroidMediaCamera *m_cam;
+  DroidMediaCodecDataCallbacks m_cb;
+  void *m_cb_data;
+  android::sp<android::CameraSource> m_src;
+  android::sp<android::MediaSource> m_codec;
+  bool m_running;
+  pthread_t m_thread;
+};
+
+extern "C" {
+DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidMediaCodecEncoderMetaData *meta, int camWidth, int camHeight, int32_t camFrameRate) {
+
+  android::Size size(camWidth, camHeight);
+  DroidMediaRecorder *recorder = new DroidMediaRecorder;
+  recorder->m_cam = camera;
+  android::sp<android::Camera> cam(droid_media_camera_get_camera (camera));
+  recorder->m_src = android::CameraSource::CreateFromCamera(cam->remote(),
+							    cam->getRecordingProxy(), // proxy
+							    -1, // cameraId
+							    android::String16(), // clientName
+							    -1, // clientUid
+							    size,  // videoSize
+							    camFrameRate, // frameRate
+							    NULL, // surface
+							    meta->meta_data// storeMetaDataInVideoBuffers
+							    );
+
+  // Now the encoder:
+  recorder->m_codec = (droid_media_codec_create_encoder_raw(meta, recorder->m_src));
+
+  return recorder;
+}
+
+void droid_media_recorder_destroy(DroidMediaRecorder *recorder) {
+  recorder->m_codec.clear();
+  recorder->m_src.clear();
+
+  delete recorder;
+}
+
+bool droid_media_recorder_start(DroidMediaRecorder *recorder) {
+  recorder->m_running = true;
+
+  int err = recorder->m_codec->start();
+
+  if (err != android::OK) {
+    ALOGE("DroidMediaRecorder: error 0x%x starting codec", -err);
+    return false;
+  }
+
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+  pthread_create(&recorder->m_thread, &attr, DroidMediaRecorder::ThreadWrapper, recorder);
+  pthread_attr_destroy(&attr);
+
+  return true;
+}
+
+void droid_media_recorder_stop(DroidMediaRecorder *recorder) {
+  recorder->m_running = false;
+  void *dummy;
+  pthread_join(recorder->m_thread, &dummy);
+}
+
+void droid_media_recorder_set_data_callbacks(DroidMediaRecorder *recorder,
+					     DroidMediaCodecDataCallbacks *cb, void *data) {
+  memcpy(&recorder->m_cb, cb, sizeof(recorder->m_cb));
+  recorder->m_cb_data = data;
+}
+
+};

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -84,7 +84,6 @@ struct _DroidMediaRecorder {
     while (m_running && err == android::OK) {
       err = tick();
     }
-
     return NULL;
   }
 
@@ -157,6 +156,11 @@ void droid_media_recorder_stop(DroidMediaRecorder *recorder) {
   recorder->m_running = false;
   void *dummy;
   pthread_join(recorder->m_thread, &dummy);
+
+  int err = recorder->m_codec->stop();
+  if (err != android::OK) {
+      ALOGE("DroidMediaRecorder: error 0x%x stopping codec", -err);
+  }
 }
 
 void droid_media_recorder_set_data_callbacks(DroidMediaRecorder *recorder,

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -102,9 +102,9 @@ struct _DroidMediaRecorder {
 };
 
 extern "C" {
-DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidMediaCodecEncoderMetaData *meta, int camWidth, int camHeight, int32_t camFrameRate) {
+DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidMediaCodecEncoderMetaData *meta) {
 
-  android::Size size(camWidth, camHeight);
+  android::Size size(meta->parent.width, meta->parent.height);
   DroidMediaRecorder *recorder = new DroidMediaRecorder;
   recorder->m_cam = camera;
   android::sp<android::Camera> cam(droid_media_camera_get_camera (camera));
@@ -116,7 +116,7 @@ DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidM
 							    -1, // clientUid
 #endif
 							    size,  // videoSize
-							    camFrameRate, // frameRate
+							    meta->parent.fps, // frameRate
 							    NULL, // surface
 							    meta->meta_data// storeMetaDataInVideoBuffers
 							    );

--- a/droidmediarecorder.h
+++ b/droidmediarecorder.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Jolla Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Mohammed Hassan <mohammed.hassan@jolla.com>
+ */
+
+#ifndef DROID_MEDIA_RECORDER_H
+#define DROID_MEDIA_RECORDER_H
+
+#include "droidmedia.h"
+#include "droidmediacamera.h"
+#include "droidmediacodec.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _DroidMediaRecorder DroidMediaRecorder;
+
+DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidMediaCodecEncoderMetaData *meta, int camWidth, int camHeight, int32_t camFrameRate);
+void droid_media_recorder_destroy(DroidMediaRecorder *recorder);
+
+bool droid_media_recorder_start(DroidMediaRecorder *recorder);
+void droid_media_recorder_stop(DroidMediaRecorder *recorder);
+
+void droid_media_recorder_set_data_callbacks(DroidMediaRecorder *recorder,
+					     DroidMediaCodecDataCallbacks *cb, void *data);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* DROID_MEDIA_RECORDER_H */

--- a/droidmediarecorder.h
+++ b/droidmediarecorder.h
@@ -30,7 +30,7 @@ extern "C" {
 
 typedef struct _DroidMediaRecorder DroidMediaRecorder;
 
-DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidMediaCodecEncoderMetaData *meta, int camWidth, int camHeight, int32_t camFrameRate);
+DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidMediaCodecEncoderMetaData *meta);
 void droid_media_recorder_destroy(DroidMediaRecorder *recorder);
 
 bool droid_media_recorder_start(DroidMediaRecorder *recorder);

--- a/hybris.c
+++ b/hybris.c
@@ -20,6 +20,7 @@
 #include "droidmediacodec.h"
 #include "droidmediaconvert.h"
 #include "droidmediaconstants.h"
+#include "droidmediarecorder.h"
 #include <dlfcn.h>
 #include <assert.h>
 #include <stdio.h>
@@ -97,6 +98,14 @@ static inline void *__resolve_sym(const char *sym)
       _sym = __resolve_sym(#sym);				     \
     return _sym(_arg0,_arg1, _arg2, _arg3);			     \
   }								     \
+
+#define HYBRIS_WRAPPER_1_5(ret,arg0,arg1,arg2,arg3,arg4,sym)		\
+  ret sym(arg0 _arg0, arg1 _arg1, arg2 _arg2, arg3 _arg3, arg4 _arg4) { \
+    static ret (* _sym)(arg0, arg1, arg2, arg3, arg4) = NULL;		\
+    if (!_sym)								\
+      _sym = __resolve_sym(#sym);					\
+    return _sym(_arg0,_arg1, _arg2, _arg3, _arg4);			\
+  }									\
 
 #define HYBRIS_WRAPPER_1_6(ret,arg0,arg1,arg2,arg3,arg4,arg5,sym)	\
   ret sym(arg0 _arg0, arg1 _arg1, arg2 _arg2, arg3 _arg3, arg4 _arg4, arg5 _arg5) { \
@@ -219,3 +228,9 @@ HYBRIS_WRAPPER_0_1(DroidMediaConvert*,droid_media_convert_destroy);
 HYBRIS_WRAPPER_1_3(bool,DroidMediaConvert*,DroidMediaData*,void*,droid_media_convert_to_i420);
 HYBRIS_WRAPPER_0_4(DroidMediaConvert*,DroidMediaRect,int32_t,int32_t,droid_media_convert_set_crop_rect);
 HYBRIS_WRAPPER_1_1(bool,DroidMediaConvert*,droid_media_convert_is_i420);
+
+HYBRIS_WRAPPER_1_5(DroidMediaRecorder*,DroidMediaCamera*,DroidMediaCodecEncoderMetaData*,int,int,int32_t,droid_media_recorder_create);
+HYBRIS_WRAPPER_0_1(DroidMediaRecorder*,droid_media_recorder_destroy);
+HYBRIS_WRAPPER_1_1(bool,DroidMediaRecorder*,droid_media_recorder_start);
+HYBRIS_WRAPPER_0_1(DroidMediaRecorder*,droid_media_recorder_stop);
+HYBRIS_WRAPPER_0_3(DroidMediaRecorder*,DroidMediaCodecDataCallbacks*,void*,droid_media_recorder_set_data_callbacks);

--- a/hybris.c
+++ b/hybris.c
@@ -99,14 +99,6 @@ static inline void *__resolve_sym(const char *sym)
     return _sym(_arg0,_arg1, _arg2, _arg3);			     \
   }								     \
 
-#define HYBRIS_WRAPPER_1_5(ret,arg0,arg1,arg2,arg3,arg4,sym)		\
-  ret sym(arg0 _arg0, arg1 _arg1, arg2 _arg2, arg3 _arg3, arg4 _arg4) { \
-    static ret (* _sym)(arg0, arg1, arg2, arg3, arg4) = NULL;		\
-    if (!_sym)								\
-      _sym = __resolve_sym(#sym);					\
-    return _sym(_arg0,_arg1, _arg2, _arg3, _arg4);			\
-  }									\
-
 #define HYBRIS_WRAPPER_1_6(ret,arg0,arg1,arg2,arg3,arg4,arg5,sym)	\
   ret sym(arg0 _arg0, arg1 _arg1, arg2 _arg2, arg3 _arg3, arg4 _arg4, arg5 _arg5) { \
     static ret (* _sym)(arg0, arg1, arg2, arg3, arg4, arg5) = NULL;	\
@@ -229,7 +221,7 @@ HYBRIS_WRAPPER_1_3(bool,DroidMediaConvert*,DroidMediaData*,void*,droid_media_con
 HYBRIS_WRAPPER_0_4(DroidMediaConvert*,DroidMediaRect,int32_t,int32_t,droid_media_convert_set_crop_rect);
 HYBRIS_WRAPPER_1_1(bool,DroidMediaConvert*,droid_media_convert_is_i420);
 
-HYBRIS_WRAPPER_1_5(DroidMediaRecorder*,DroidMediaCamera*,DroidMediaCodecEncoderMetaData*,int,int,int32_t,droid_media_recorder_create);
+HYBRIS_WRAPPER_1_2(DroidMediaRecorder*,DroidMediaCamera*,DroidMediaCodecEncoderMetaData*,droid_media_recorder_create);
 HYBRIS_WRAPPER_0_1(DroidMediaRecorder*,droid_media_recorder_destroy);
 HYBRIS_WRAPPER_1_1(bool,DroidMediaRecorder*,droid_media_recorder_start);
 HYBRIS_WRAPPER_0_1(DroidMediaRecorder*,droid_media_recorder_stop);

--- a/private.h
+++ b/private.h
@@ -22,6 +22,7 @@
 #include "droidmedia.h"
 #include <gui/BufferQueue.h>
 #include <camera/Camera.h>
+#include "droidmediacamera.h"
 
 class DroidMediaBufferQueueListener :
 #if (ANDROID_MAJOR == 4 && ANDROID_MINOR == 4) || ANDROID_MAJOR == 5
@@ -77,5 +78,7 @@ private:
 
   android::sp<DroidMediaBufferQueueListener> m_listener;
 };
+
+android::sp<android::Camera> droid_media_camera_get_camera(DroidMediaCamera *camera);
 
 #endif /* DROID_MEDIA_PRIVATE_H */

--- a/private.h
+++ b/private.h
@@ -22,7 +22,9 @@
 #include "droidmedia.h"
 #include <gui/BufferQueue.h>
 #include <camera/Camera.h>
+#include <media/stagefright/MediaSource.h>
 #include "droidmediacamera.h"
+#include "droidmediacodec.h"
 
 class DroidMediaBufferQueueListener :
 #if (ANDROID_MAJOR == 4 && ANDROID_MINOR == 4) || ANDROID_MAJOR == 5
@@ -80,5 +82,7 @@ private:
 };
 
 android::sp<android::Camera> droid_media_camera_get_camera(DroidMediaCamera *camera);
-
+android::sp<android::MediaSource> droid_media_codec_create_encoder_raw(DroidMediaCodecEncoderMetaData *meta,
+							      android::sp<android::MediaSource> src);
+ 
 #endif /* DROID_MEDIA_PRIVATE_H */


### PR DESCRIPTION
droidmediarecorder is a set of API to enable the usage of android stagefright encoders directly by camera. This gives us the ability to push encoded video from camera.