### PR TITLE
[minisf] Add fake batterystats service. Contributes JB#37491

### DIFF
--- a/minisf.cpp
+++ b/minisf.cpp
@@ -113,6 +113,32 @@ public:
     	return 0;
     }
 };
+
+#include <binder/IBatteryStats.h>
+
+class FakeBatteryStats : public BinderService<FakeBatteryStats>,
+                                public BnBatteryStats
+{
+public:
+    static char const *getServiceName() {
+        return "batterystats";
+    }
+    void noteStartSensor(int uid, int sensor) {  }
+    void noteStopSensor(int uid, int sensor) {  }
+    void noteStartVideo(int uid) {  }
+    void noteStopVideo(int uid) {  }
+    void noteStartAudio(int uid) {  }
+    void noteStopAudio(int uid) {  }
+    void noteResetVideo() {  }
+    void noteResetAudio() {  }
+    void noteFlashlightOn(int uid) {  }
+    void noteFlashlightOff(int uid) {  }
+    void noteStartCamera(int uid) {  }
+    void noteStopCamera(int uid) {  }
+    void noteResetCamera() {  }
+    void noteResetFlashlight() {  }
+};
+
 #endif
 
 using namespace android;
@@ -158,6 +184,7 @@ main(int, char**)
 
 #if ANDROID_MAJOR >= 6
     FakeProcessInfoService::instantiate();
+    FakeBatteryStats::instantiate();
 #endif
 
     ProcessState::self()->startThreadPool();


### PR DESCRIPTION
Batterystats is a new service for tracking multimedia usage in Android 6+. Qualcomm blobs call it when the camera starts and stops. The calls don't seem to block UI, but some background threads do as they wait for the service manager to timeout.

In the longer term it may be useful to record this data in Sailfish.