### PR TITLE
Android 7 support

### DIFF
--- a/allocator.cpp
+++ b/allocator.cpp
@@ -19,6 +19,8 @@
 #include "allocator.h"
 #include <ui/GraphicBuffer.h>
 
+#define LOG_TAG "DroidMediaAllocator"
+
 DroidMediaAllocator::DroidMediaAllocator() :
     m_size(0)
 {
@@ -52,7 +54,7 @@ DroidMediaAllocator::createGraphicBuffer(uint32_t w, uint32_t h,
     *error = err;
 
     if (err != android::NO_ERROR || graphicBuffer->handle == 0) {
-        ALOGE("DroidMediaAllocator::createGraphicBuffer(w=%d, h=%d) "
+        ALOGE("createGraphicBuffer(w=%d, h=%d) "
               "failed (%s), handle=%p, format=0x%x, usage=0x%x, size=%d",
               w, h, strerror(-err), graphicBuffer->handle, format, usage, m_size);
         return 0;

--- a/droidmedia.h
+++ b/droidmedia.h
@@ -89,6 +89,7 @@ uint64_t droid_media_buffer_get_frame_number(DroidMediaBuffer * buffer);
 DroidMediaRect droid_media_buffer_get_crop_rect(DroidMediaBuffer * buffer);
 uint32_t droid_media_buffer_get_width(DroidMediaBuffer * buffer);
 uint32_t droid_media_buffer_get_height(DroidMediaBuffer * buffer);
+const void *droid_media_buffer_get_handle(DroidMediaBuffer *buffer);
 void droid_media_buffer_release(DroidMediaBuffer *buffer,
 				EGLDisplay display, EGLSyncKHR fence);
 

--- a/droidmediabuffer.cpp
+++ b/droidmediabuffer.cpp
@@ -19,6 +19,8 @@
 #include "droidmediabuffer.h"
 #include "private.h"
 
+#define LOG_TAG "DroidMediaBuffer"
+
 #if ANDROID_MAJOR < 5
 static const int staleBuffer = android::BufferQueue::STALE_BUFFER_SLOT;
 #else
@@ -122,7 +124,7 @@ DroidMediaBuffer *droid_media_buffer_create_from_raw_data(uint32_t w, uint32_t h
   android::status_t err = buffer->initCheck();
 
   if (err != android::NO_ERROR) {
-    ALOGE("DroidMediaBuffer: Error 0x%x allocating buffer", -err);
+    ALOGE("Error 0x%x allocating buffer", -err);
     buffer.clear();
     return NULL;
   }
@@ -130,7 +132,7 @@ DroidMediaBuffer *droid_media_buffer_create_from_raw_data(uint32_t w, uint32_t h
   err = buffer->lock(android::GraphicBuffer::USAGE_SW_READ_RARELY
 		     | android::GraphicBuffer::USAGE_SW_WRITE_RARELY, &addr);
   if (err != android::NO_ERROR) {
-    ALOGE("DroidMediaBuffer: Error 0x%x locking buffer", -err);
+    ALOGE("Error 0x%x locking buffer", -err);
     buffer.clear();
     return NULL;
   }
@@ -166,7 +168,7 @@ DroidMediaBuffer *droid_media_buffer_create_from_raw_data(uint32_t w, uint32_t h
 out:
   err = buffer->unlock();
   if (err != android::NO_ERROR) {
-    ALOGE("DroidMediaBuffer: Error 0x%x unlocking buffer", -err);
+    ALOGE("Error 0x%x unlocking buffer", -err);
     buffer.clear();
     return NULL;
   }
@@ -190,11 +192,11 @@ void droid_media_buffer_release(DroidMediaBuffer *buffer,
         break;
 
     case staleBuffer:
-        ALOGW("DroidMediaBuffer: Released stale buffer %d", buffer->m_slot);
+        ALOGW("Released stale buffer %d", buffer->m_slot);
         break;
 
     default:
-        ALOGE("DroidMediaBuffer: Error 0x%x releasing buffer %d", -err, buffer->m_slot);
+        ALOGE("Error 0x%x releasing buffer %d", -err, buffer->m_slot);
         break;
     }
 

--- a/droidmediabuffer.cpp
+++ b/droidmediabuffer.cpp
@@ -244,6 +244,11 @@ uint32_t droid_media_buffer_get_height(DroidMediaBuffer * buffer)
     return buffer->height;
 }
 
+const void *droid_media_buffer_get_handle(DroidMediaBuffer *buffer)
+{
+    return buffer->handle;
+}
+
 void droid_media_buffer_get_info(DroidMediaBuffer *buffer, DroidMediaBufferInfo *info)
 {
     info->width = buffer->width;

--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -216,7 +216,7 @@ public:
 #if ANDROID_MAJOR >= 7
     void postRecordingFrameHandleTimestamp(nsecs_t timestamp, native_handle_t* handle) 
     {
-        // Ignore for now
+    	ALOGW("postRecordingFrameHandleTimestamp - not sure what to do");
     }
 #endif
 
@@ -279,14 +279,14 @@ bool droid_media_camera_get_info(DroidMediaCameraInfo *info, int camera_number)
 
 DroidMediaCamera *droid_media_camera_connect(int camera_number)
 {
-  android::sp<DroidMediaBufferQueueListener> listener(new DroidMediaBufferQueueListener);
+    android::sp<DroidMediaBufferQueueListener> listener(new DroidMediaBufferQueueListener);
 
     android::sp<DroidMediaBufferQueue>
       queue(new DroidMediaBufferQueue("DroidMediaCameraBufferQueue"));
     if (!queue->connectListener()) {
         ALOGE("Failed to connect buffer queue listener");
-	queue.clear();
-	listener.clear();
+        queue.clear();
+        listener.clear();
         return NULL;
     }
 
@@ -400,8 +400,13 @@ bool droid_media_camera_store_meta_data_in_buffers(DroidMediaCamera *camera, boo
 #if ANDROID_MAJOR < 7
     return camera->m_camera->storeMetaDataInBuffers(enabled) == android::NO_ERROR;
 #else
-    // TODO: assess whether we should still support this in Android 7. Lots of cameras seem to not support it
-    return false;
+    if (android::OK == camera->m_camera->setVideoBufferMode(
+            android::hardware::ICamera::VIDEO_BUFFER_MODE_BUFFER_QUEUE)) {
+        ALOGI("Recording in buffer queue mode");
+        return true;
+    } else {
+        return false;
+    }
 #endif
 }
 

--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -28,6 +28,8 @@
 #include "droidmediabuffer.h"
 #include "private.h"
 
+#define LOG_TAG "DroidMediaCamera"
+
 namespace android {
 	int32_t getColorFormat(const char* colorFormat) {
 		if (!strcmp(colorFormat, CameraParameters::PIXEL_FORMAT_YUV420P)) {
@@ -123,7 +125,7 @@ public:
                 }
                 break;
             default:
-                ALOGW("DroidMediaCamera: unknown notify message 0x%x", msgType);
+                ALOGW("unknown notify message 0x%x", msgType);
                 break;
         }
     }
@@ -180,7 +182,7 @@ public:
               break;
 
             default:
-                ALOGW("DroidMediaCamera: unknown postData message 0x%x", dataMsgType);
+                ALOGW("unknown postData message 0x%x", dataMsgType);
                 break;
         }
 
@@ -207,7 +209,7 @@ public:
                 break;
 
             default:
-                ALOGW("DroidMediaCamera: unknown postDataTimestamp message 0x%x", msgType);
+                ALOGW("unknown postDataTimestamp message 0x%x", msgType);
                 break;
         }
     }

--- a/droidmediaconvert.cpp
+++ b/droidmediaconvert.cpp
@@ -25,6 +25,8 @@
 
 typedef void (*_getI420ColorConverter)(II420ColorConverter *converter);
 
+#define LOG_TAG "DroidMediaConvert"
+
 extern "C" {
 
 struct _DroidMediaConvert : public II420ColorConverter
@@ -45,19 +47,19 @@ public:
 
     bool init() {
         if (m_handle) {
-            ALOGW("DroidMediaConvert: already loaded");
+            ALOGW("already loaded");
             return true;
         }
 
         m_handle = dlopen("libI420colorconvert.so", RTLD_NOW);
         if (!m_handle) {
-            ALOGE("DroidMediaConvert: failed to load libI420colorconvert.so. %s", dlerror());
+            ALOGE("failed to load libI420colorconvert.so. %s", dlerror());
             return false;
         }
 
         _getI420ColorConverter func = (_getI420ColorConverter)dlsym(m_handle, "getI420ColorConverter");
         if (!func) {
-            ALOGE("DroidMediaConvert: failed to find symbol getI420ColorConverter");
+            ALOGE("failed to find symbol getI420ColorConverter");
             dlclose(m_handle);
             m_handle = NULL;
             return false;
@@ -97,7 +99,7 @@ bool droid_media_convert_to_i420(DroidMediaConvert *convert, DroidMediaData *in,
 	convert->m_crop.right == -1 ||
 	convert->m_crop.bottom == -1) {
 
-      ALOGE("DroidMediaConvert: crop rectangle not set");
+      ALOGE("crop rectangle not set");
 
       return false;
     }
@@ -108,7 +110,7 @@ bool droid_media_convert_to_i420(DroidMediaConvert *convert, DroidMediaData *in,
                                               out);
 
     if (err != android::NO_ERROR) {
-        ALOGE("DroidMediaConvert: error 0x%x converting buffer", -err);
+        ALOGE("error 0x%x converting buffer", -err);
         return false;
     }
 

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -50,7 +50,7 @@ struct _DroidMediaRecorder {
     android::MediaBuffer *buffer;
     android::status_t err = m_codec->read(&buffer);
 
-    if (buffer) {
+    if (err == android::OK) {
       DroidMediaCodecData data;
       data.data.data = (uint8_t *)buffer->data() + buffer->range_offset();
       data.data.size = buffer->range_length();
@@ -67,7 +67,7 @@ struct _DroidMediaRecorder {
         // Convert timestamp from useconds to nseconds
         data.ts *= 1000;
       } else {
-        if (!data.codec_config) ALOGE("Received a buffer without a timestamp!");
+        if (!data.codec_config) ALOGE("Recorder received a buffer without a timestamp!");
       }
 
       if (buffer->meta_data()->findInt64(android::kKeyDecodingTime, &data.decoding_ts)) {
@@ -151,7 +151,7 @@ DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidM
 #endif
   // fetch the colour format
   recorder->m_src->getFormat()->findInt32(android::kKeyColorFormat, &meta->color_format);
-  
+
   // Now the encoder:
 #if ANDROID_MAJOR >= 5
   recorder->m_codec = droid_media_codec_create_encoder_raw(meta, recorder->m_looper, recorder->m_src);

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -28,6 +28,8 @@
 #include <media/stagefright/foundation/ALooper.h>
 #endif
 
+#define LOG_TAG "DroidMediaRecorder"
+
 namespace android {
   class CameraSourceListener {
   public:
@@ -65,7 +67,7 @@ struct _DroidMediaRecorder {
         // Convert timestamp from useconds to nseconds
         data.ts *= 1000;
       } else {
-        if (!data.codec_config) ALOGE("DroidMediaRecorder: Received a buffer without a timestamp!");
+        if (!data.codec_config) ALOGE("Received a buffer without a timestamp!");
       }
 
       if (buffer->meta_data()->findInt64(android::kKeyDecodingTime, &data.decoding_ts)) {
@@ -176,7 +178,7 @@ bool droid_media_recorder_start(DroidMediaRecorder *recorder) {
   int err = recorder->m_codec->start();
 
   if (err != android::OK) {
-    ALOGE("DroidMediaRecorder: error 0x%x starting codec", -err);
+    ALOGE("error 0x%x starting codec", -err);
     return false;
   }
 
@@ -196,7 +198,7 @@ void droid_media_recorder_stop(DroidMediaRecorder *recorder) {
 
   int err = recorder->m_codec->stop();
   if (err != android::OK) {
-      ALOGE("DroidMediaRecorder: error 0x%x stopping codec", -err);
+      ALOGE("error 0x%x stopping codec", -err);
   }
 }
 

--- a/hybris.c
+++ b/hybris.c
@@ -193,6 +193,7 @@ HYBRIS_WRAPPER_1_1(uint64_t,DroidMediaBuffer*,droid_media_buffer_get_frame_numbe
 HYBRIS_WRAPPER_1_1(DroidMediaRect,DroidMediaBuffer*,droid_media_buffer_get_crop_rect)
 HYBRIS_WRAPPER_1_1(uint32_t,DroidMediaBuffer*,droid_media_buffer_get_width);
 HYBRIS_WRAPPER_1_1(uint32_t,DroidMediaBuffer*,droid_media_buffer_get_height);
+HYBRIS_WRAPPER_1_1(const void*,DroidMediaBuffer*,droid_media_buffer_get_handle);
 HYBRIS_WRAPPER_1_1(DroidMediaCodec*,DroidMediaCodecDecoderMetaData*,droid_media_codec_create_decoder);
 HYBRIS_WRAPPER_1_1(DroidMediaCodec*,DroidMediaCodecEncoderMetaData*,droid_media_codec_create_encoder);
 HYBRIS_WRAPPER_1_1(bool,DroidMediaCodec*,droid_media_codec_start);

--- a/minimedia.cpp
+++ b/minimedia.cpp
@@ -33,6 +33,8 @@
 #include <cutils/multiuser.h>
 #endif
 
+#define LOG_TAG "MinimediaService"
+
 // echo "persist.camera.shutter.disable=1" >> /system/build.prop
 
 using namespace android;
@@ -78,10 +80,10 @@ main(int, char**)
         if (binder != NULL) {
             break;
         }
-        ALOGW("DroidMedia: Camera service is not yet available, waiting...");
+        ALOGW("Camera service is not yet available, waiting...");
         usleep(BINDER_SERVICE_CHECK_INTERVAL);
     } while (true);
-    ALOGD("DroidMedia: Allowing use of the camera for users root and bin");
+    ALOGD("Allowing use of the camera for users root and bin");
 #if ANDROID_MAJOR >= 7
     sp<hardware::ICameraService> gCameraService = interface_cast<hardware::ICameraService>(binder);
     std::vector<int32_t> users = {0, 1};

--- a/private.cpp
+++ b/private.cpp
@@ -24,6 +24,8 @@
 #include <gui/Surface.h>
 #endif
 
+#define LOG_TAG "DroidMediaBufferQueue"
+
 DroidMediaBufferQueueListener::DroidMediaBufferQueueListener() :
 #if (ANDROID_MAJOR == 4 && ANDROID_MINOR == 4) || ANDROID_MAJOR >= 5
   ProxyConsumerListener(NULL),
@@ -157,7 +159,7 @@ DroidMediaBuffer *_DroidMediaBufferQueue::acquireMediaBuffer(DroidMediaBufferCal
 #endif
 
   if (err != android::OK) {
-    ALOGE("DroidMediaBufferQueue: Failed to acquire buffer from the queue. Error 0x%x", -err);
+    ALOGE("Failed to acquire buffer from the queue. Error 0x%x", -err);
     return NULL;
   }
 
@@ -181,13 +183,13 @@ DroidMediaBuffer *_DroidMediaBufferQueue::acquireMediaBuffer(DroidMediaBufferCal
   }
 
   if (m_slots[num].mGraphicBuffer == NULL) {
-    ALOGE("DroidMediaBufferQueue: Got a buffer without real data");
+    ALOGE("Got a buffer without real data");
 
     DroidMediaBuffer *buffer = new DroidMediaBuffer(m_slots[num], this, NULL, NULL, NULL);
     err = releaseMediaBuffer(buffer, EGL_NO_DISPLAY, EGL_NO_SYNC_KHR);
 
     if (err != android::NO_ERROR) {
-      ALOGE("DroidMediaBufferQueue: error releasing buffer. Error 0x%x", -err);
+      ALOGE("error releasing buffer. Error 0x%x", -err);
     }
 
     return NULL;


### PR DESCRIPTION
Added a getHandle method to export buffers to gstreamer-omx.
Added support for Android 7's VIDEO_BUFFER_MODE_BUFFER_QUEUE, passing video buffers from the camera to the codec. The output buffers of the codec are not permitted to use buffers, but by that point the video as been encoded to the cost isn't too bad.