### PR TITLE
WIP: Pass default stride and slice height parameters to the recorder

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -48,7 +48,17 @@ LOCAL_SHARED_LIBRARIES := libc \
                           libbinder \
                           libstagefright \
                           libstagefright_foundation \
-                          libmedia
+                          libstagefright_httplive \
+                          libmedia \
+                          libmediaplayerservice \
+                          libdrmframework \
+                          libcrypto
+
+LOCAL_STATIC_LIBRARIES := libstagefright_nuplayer \
+                          libstagefright_rtsp 
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libavmediaserviceextensions
+
 LOCAL_CPPFLAGS=-DANDROID_MAJOR=$(ANDROID_MAJOR) -DANDROID_MINOR=$(ANDROID_MINOR) -DANDROID_MICRO=$(ANDROID_MICRO)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libdroidmedia
@@ -60,7 +70,9 @@ ifeq ($(strip $(ANDROID_MAJOR)),7)
 LOCAL_C_INCLUDES := frameworks/native/include/media/openmax \
                     frameworks/native/include/media/hardware
 else
-LOCAL_C_INCLUDES := frameworks/native/include/media/openmax
+LOCAL_C_INCLUDES := frameworks/native/include/media/openmax \
+                    frameworks/av/media/libavextensions \
+                    frameworks/av/media/libstagefright/mpeg2ts
 endif
 
 include $(BUILD_SHARED_LIBRARY)

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -416,7 +416,9 @@ public:
         android::sp<android::AMessage> format = new android::AMessage();
         format->setString("mime", mime);
         ALOGW("Creating audio encoder for %s", mime);
-        format->setInt32("aac-profile", OMX_AUDIO_AACObjectLC);
+        if (!strcmp (mime, android::MEDIA_MIMETYPE_AUDIO_AAC)) {
+            format->setInt32("aac-profile", OMX_AUDIO_AACObjectLC);
+        }
 
         int32_t maxinput, channels, samplerate, bitrate;
         if (md->findInt32(android::kKeyMaxInputSize, &maxinput)) {

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -27,6 +27,7 @@
 #if ANDROID_MAJOR >=5
 #include <media/stagefright/foundation/ALooper.h>
 #endif
+#include <stagefright/AVExtensions.h>
 
 #define LOG_TAG "DroidMediaRecorder"
 
@@ -127,7 +128,7 @@ DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidM
   recorder->m_looper->start();
 #endif
 
-  recorder->m_src = android::CameraSource::CreateFromCamera(cam->remote(),
+  recorder->m_src = android::AVFactory::get()->CreateCameraSourceFromCamera(cam->remote(),
 							    cam->getRecordingProxy(), // proxy
 							    -1, // cameraId
 #if (ANDROID_MAJOR == 4 && ANDROID_MINOR == 4) || ANDROID_MAJOR >= 5
@@ -142,7 +143,7 @@ DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidM
 							    NULL, // surface
 								meta->meta_data // storeMetaDataInVideoBuffers
 							    );
-
+  android::AVUtils::get()->cacheCaptureBuffers(cam->remote(), (android::video_encoder)3); //AVC
   // set metadata storage in codec according to whether the camera request was successful
 #if ANDROID_MAJOR >= 7
   meta->meta_data = recorder->m_src->metaDataStoredInVideoBuffers();
@@ -161,7 +162,6 @@ DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidM
 #else
   recorder->m_codec = droid_media_codec_create_encoder_raw(meta, recorder->m_src);
 #endif
-
   return recorder;
 
 }

--- a/droidmediarecorder.cpp
+++ b/droidmediarecorder.cpp
@@ -149,8 +149,11 @@ DroidMediaRecorder *droid_media_recorder_create(DroidMediaCamera *camera, DroidM
 #else
   meta->meta_data = recorder->m_src->isMetaDataStoredInVideoBuffers();
 #endif
-  // fetch the colour format
-  recorder->m_src->getFormat()->findInt32(android::kKeyColorFormat, &meta->color_format);
+  // pass important metadata to the recorder
+  android::sp<android::MetaData> md = recorder->m_src->getFormat();
+  md->findInt32(android::kKeyStride, &meta->stride);
+  md->findInt32(android::kKeySliceHeight, &meta->slice_height);
+  md->findInt32(android::kKeyColorFormat, &meta->color_format);
 
   // Now the encoder:
 #if ANDROID_MAJOR >= 5


### PR DESCRIPTION
One Android 6 based device crashes on recording start without these values set when using MediaCodecSource.