### PR TITLE
Support HAL1 cameras

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,6 +3,11 @@ LOCAL_PATH:= $(call my-dir)
 ANDROID_MAJOR :=
 ANDROID_MINOR :=
 ANDROID_MICRO :=
+FORCE_HAL_PARAM :=
+
+ifdef FORCE_HAL
+FORCE_HAL_PARAM := -DFORCE_HAL=$(FORCE_HAL)
+endif
 
 ifndef ANDROID_MAJOR
 include build/core/version_defaults.mk
@@ -49,7 +54,7 @@ LOCAL_SHARED_LIBRARIES := libc \
                           libstagefright \
                           libstagefright_foundation \
                           libmedia
-LOCAL_CPPFLAGS=-DANDROID_MAJOR=$(ANDROID_MAJOR) -DANDROID_MINOR=$(ANDROID_MINOR) -DANDROID_MICRO=$(ANDROID_MICRO)
+LOCAL_CPPFLAGS=-DANDROID_MAJOR=$(ANDROID_MAJOR) -DANDROID_MINOR=$(ANDROID_MINOR) -DANDROID_MICRO=$(ANDROID_MICRO) $(FORCE_HAL_PARAM)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libdroidmedia
 ifeq ($(strip $(BOARD_QTI_CAMERA_32BIT_ONLY)), true)

--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -298,15 +298,22 @@ DroidMediaCamera *droid_media_camera_connect(int camera_number)
 
 #if (ANDROID_MAJOR == 4 && ANDROID_MINOR < 4)
     cam->m_camera = android::Camera::connect(camera_number);
-#elif ANDROID_MAJOR <= 6
+#elif (ANDROID_MAJOR == 4 && ANDROID_MINOR == 4)
     cam->m_camera = android::Camera::connect(camera_number, android::String16("droidmedia"),
 					     android::Camera::USE_CALLING_UID);
-#else
+#else // Force HAL version if defined
+#ifdef FORCE_HAL
+    ALOGI("Connecting HAL version %d", FORCE_HAL);
+    android::OK != android::Camera::connectLegacy(camera_number, FORCE_HAL << 8, android::String16("droidmedia"),
+					     android::Camera::USE_CALLING_UID, cam->m_camera);
+#else // Default connect
     cam->m_camera = android::Camera::connect(camera_number, android::String16("droidmedia"),
-					     android::Camera::USE_CALLING_UID, android::Camera::USE_CALLING_PID);
-// This would open a HAL1 camera, but everything seems to work with default HAL3 
-//    android::Camera::connectLegacy(camera_number, 1 << 8, android::String16("droidmedia"),
-//					     android::Camera::USE_CALLING_UID, cam->m_camera);
+					     android::Camera::USE_CALLING_UID
+#if (ANDROID_MAJOR >= 7)
+					     , android::Camera::USE_CALLING_PID
+#endif
+					      );
+#endif
 #endif
     if (cam->m_camera.get() == NULL) {
         delete cam;

--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -400,13 +400,21 @@ bool droid_media_camera_store_meta_data_in_buffers(DroidMediaCamera *camera, boo
 #if ANDROID_MAJOR < 7
     return camera->m_camera->storeMetaDataInBuffers(enabled) == android::NO_ERROR;
 #else
-    if (android::OK == camera->m_camera->setVideoBufferMode(
-            android::hardware::ICamera::VIDEO_BUFFER_MODE_BUFFER_QUEUE)) {
-        ALOGI("Recording in buffer queue mode");
-        return true;
-    } else {
-        return false;
+    if (enabled) {
+        if (android::OK == camera->m_camera->setVideoBufferMode(
+                android::hardware::ICamera::VIDEO_BUFFER_MODE_BUFFER_QUEUE)) {
+            ALOGI("Recording in buffer queue mode");
+            return true;
+        } else if (android::OK == camera->m_camera->setVideoBufferMode(
+                android::hardware::ICamera::VIDEO_BUFFER_MODE_DATA_CALLBACK_METADATA)) {
+            ALOGI("Recording in callback metadata mode");
+            return true;
+        }
     }
+    camera->m_camera->setVideoBufferMode(
+                android::hardware::ICamera::VIDEO_BUFFER_MODE_DATA_CALLBACK_YUV);
+    ALOGI("Recording in callback yuv mode");
+    return !enabled; // false if metadata mode was requested.
 #endif
 }
 

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -393,7 +393,7 @@ public:
 
 #if ANDROID_MAJOR >= 7
       if (m_enc->meta_data) {
-          format->setInt32("android._input-metadata-buffer-type", android::kMetadataBufferTypeANWBuffer);
+          format->setInt32("android._input-metadata-buffer-type", m_enc->meta_data);
           format->setInt32("android._store-metadata-in-buffers-output", false);
       }
       format->setInt32("android._using-recorder", 1);
@@ -416,7 +416,9 @@ public:
         android::sp<android::AMessage> format = new android::AMessage();
         format->setString("mime", mime);
         ALOGW("Creating audio encoder for %s", mime);
-        format->setInt32("aac-profile", OMX_AUDIO_AACObjectLC);
+        if (!strcmp (mime, android::MEDIA_MIMETYPE_AUDIO_AAC)) {
+            format->setInt32("aac-profile", OMX_AUDIO_AACObjectLC);
+        }
 
         int32_t maxinput, channels, samplerate, bitrate;
         if (md->findInt32(android::kKeyMaxInputSize, &maxinput)) {

--- a/droidmediacodec.h
+++ b/droidmediacodec.h
@@ -64,7 +64,7 @@ typedef struct {
 
   int32_t color_format;
   int32_t bitrate;
-  bool meta_data;
+  int32_t meta_data;
   int32_t stride;
   int32_t slice_height;
   int32_t max_input_size;

--- a/rpm/droidmedia.spec
+++ b/rpm/droidmedia.spec
@@ -46,6 +46,12 @@ mv droidmedia* droidmedia
 popd
 
 %build
+
+%if %{?force_hal:1}%{!?force_hal:0}
+echo Forcing Camera HAL connect version %{force_hal}
+export FORCE_HAL=%{force_hal}
+%endif
+
 if (grep -qi '^BOARD_QTI_CAMERA_32BIT_ONLY := true' device/*/*/*.mk); then
 droid-make %{?_smp_mflags} libdroidmedia_32 minimediaservice minisfservice
 else


### PR DESCRIPTION
Some cameras default to HAL3+, but have only partially implemented it. This adds an OBS prjconf/environment parameter to switch to use connectLegacy instead. Support for alternative video buffer types is also needed to support recording with HAL1 cameras in Android 7.