### PR TITLE
[video] Fix SimpleDecodingSource for video. JB#41180

### DIFF
--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -671,14 +671,12 @@ DroidMediaCodec *droid_media_codec_create_encoder(DroidMediaCodecEncoderMetaData
 
 bool droid_media_codec_start(DroidMediaCodec *codec)
 {
-    if (codec->m_queue.get() != NULL) {
 #if ANDROID_MAJOR < 7
+    if (codec->m_queue.get() != NULL) {
         if (!codec->m_queue->connectListener()) {
 	    ALOGE("Failed to connect buffer queue listener");
 	    return false;
 	}
-#endif
-
 	android::status_t err = native_window_api_connect(codec->m_window.get(),
 							  NATIVE_WINDOW_API_MEDIA);
 	if (err != android::NO_ERROR) {
@@ -686,6 +684,7 @@ bool droid_media_codec_start(DroidMediaCodec *codec)
 	    return false;
 	}
     }
+#endif
 
     int err = codec->m_codec->start();
     if (err != android::OK) {
@@ -773,21 +772,21 @@ DroidMediaCodecLoopReturn droid_media_codec_loop(DroidMediaCodec *codec)
 	  return DROID_MEDIA_CODEC_LOOP_ERROR;
 	}
     }
-
-    if (err == -EWOULDBLOCK) {
-      ALOGI("retry reading again. error: 0x%x", -err);
-      return DROID_MEDIA_CODEC_LOOP_OK;
-    }
-
-#if 0
-    if (err == -EWOULDBLOCK || err == -ETIMEDOUT) {
-      ALOGI("retry reading again. error: 0x%x", -err);
-      return DROID_MEDIA_CODEC_LOOP_OK;
-    }
+    if (err == -EWOULDBLOCK
+#if ANDROID_MAJOR >= 7
+	|| err == -ENODATA
 #endif
+	) {
+      ALOGI("retry reading again. error: 0x%x", -err);
+      return DROID_MEDIA_CODEC_LOOP_OK;
+    }
 
     if (err != android::OK) {
-        if (err == android::ERROR_END_OF_STREAM || err == -ENODATA) {
+        if (err == android::ERROR_END_OF_STREAM
+#if ANDROID_MAJOR < 7
+            || err == -ENODATA
+#endif
+            ) {
             ALOGE("Got EOS");
 
             if (codec->m_cb.signal_eos) {


### PR DESCRIPTION
This fixes interaction with software OMX codecs on Android 7. Use of hardware codecs depends on this commit being present in the Android source tree: https://android.googlesource.com/platform/frameworks/av/+/ca4c68f25eb61f4d4e339e99cf63f863adc52fdd%5E!/#F0