### PR TITLE
[droidmedia] Temporarily fix android arch detection. JB#42355

### DIFF
--- a/detect_build_targets.sh
+++ b/detect_build_targets.sh
@@ -6,7 +6,7 @@ LIB_TARGET=
 if [ "$1" == "aarch64" ]; then
     : # noop
 else
-    ANDROID_ARCH=`grep -h -m 1 "TARGET_ARCH *:=" device/*/*/*.mk | sed -e 's/ *TARGET_ARCH *:= *\([a-zA-Z0-9_]*\) */\1/'`
+    ANDROID_ARCH=`cat lunch_arch`
     if [ "$ANDROID_ARCH" == "arm64" ]; then
         LIB_TARGET=_32
     fi

--- a/rpm/droidmedia.spec
+++ b/rpm/droidmedia.spec
@@ -54,7 +54,7 @@ echo FORCE_HAL := %{force_hal} >> external/droidmedia/env.mk
 
 %build
 echo "building for %{device_rpm_architecture_string}"
-
+droid-make "clean; gettargetarch > lunch_arch || echo unknown > lunch_arch"
 droid-make %{?_smp_mflags} $(external/droidmedia/detect_build_targets.sh %{device_rpm_architecture_string})
 
 %install


### PR DESCRIPTION
This is an abuse of the droid-make script to run an arbitrary command after the make, so the proper solution will be to factor out a droid-cmd instead, and call that from droid-make. This will do for 2.2.1 though, but should only be pushed to that.