### PR TITLE
Add constants for OMX_COLOR_FormatYUV420SemiPlanar

### DIFF
--- a/droidmediaconstants.cpp
+++ b/droidmediaconstants.cpp
@@ -76,6 +76,7 @@ void droid_media_colour_format_constants_init(DroidMediaColourFormatConstants *c
 {
   c->QOMX_COLOR_FormatYUV420PackedSemiPlanar32m = 0x7FA30C04;
   c->OMX_COLOR_FormatYUV420Planar = OMX_COLOR_FormatYUV420Planar;
+  c->OMX_COLOR_FormatYUV420SemiPlanar = OMX_COLOR_FormatYUV420SemiPlanar;
 }
 
 };

--- a/droidmediaconstants.h
+++ b/droidmediaconstants.h
@@ -73,6 +73,7 @@ typedef struct {
 typedef struct {
   int QOMX_COLOR_FormatYUV420PackedSemiPlanar32m;
   int OMX_COLOR_FormatYUV420Planar;
+  int OMX_COLOR_FormatYUV420SemiPlanar;
 } DroidMediaColourFormatConstants;
 
 void droid_media_camera_constants_init(DroidMediaCameraConstants *c);


### PR DESCRIPTION
This adds support for the format YUV420SemiPlanar which is used on mido and possibly others.