### PR TITLE
[build] Remove hardcoded path to allow relocating the tree

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,7 +7,7 @@ ANDROID_MINOR :=
 ANDROID_MICRO :=
 FORCE_HAL_PARAM :=
 
-include external/droidmedia/env.mk
+include $(LOCAL_PATH)/env.mk
 ifdef FORCE_HAL
 FORCE_HAL_PARAM := -DFORCE_HAL=$(FORCE_HAL)
 endif


### PR DESCRIPTION
The Android.mk contains the hardcoded path to the current directory to
include env.mk. This commit changes that to $(LOCAL_PATH) to allow
putting this repo anywhere in the Android tree. This makes including
this repo into other Android tree (e.g. Halium) easier.