### PR TITLE
droidmedia: add two functions which where introduced between android-9.0.0_r37 and android-9.0.0_r44.

### DIFF
--- a/services/services_9_0_0.h
+++ b/services/services_9_0_0.h
@@ -131,6 +131,18 @@ public:
         return BAD_VALUE;
     }
 
+    status_t captureScreen(const sp<IBinder>&,
+            sp<GraphicBuffer>*, bool&, Rect, uint32_t, uint32_t,
+            int32_t, int32_t, bool, Rotation, bool) {
+        return BAD_VALUE;
+    }
+
+    status_t captureScreen(const sp<IBinder>&,
+            sp<GraphicBuffer>*, Rect, uint32_t, uint32_t,
+            int32_t, int32_t, bool, Rotation, bool) {
+        return BAD_VALUE;
+    }
+
     status_t captureLayers(const sp<IBinder>&, sp<GraphicBuffer>*,
             const Rect&, float, bool) {
         return 0;


### PR DESCRIPTION
[droidmedia] add two functions which where introduced between android-9.0.0_r37 and android-9.0.0_r44. JB#47101