### PR TITLE
[droidmedia] Cache and re-use queue DroidMediaBuffer instances. Contributes to JB#49430

### DIFF
--- a/allocator.cpp
+++ b/allocator.cpp
@@ -41,6 +41,8 @@ DroidMediaAllocator::createGraphicBuffer(uint32_t w, uint32_t h,
 #endif
                                          android::status_t* error)
 {
+    usage |= android::GraphicBuffer::USAGE_HW_TEXTURE;
+
     // Copied from SurfaceFlinger.cpp
     android::sp<android::GraphicBuffer>
 #if (ANDROID_MAJOR == 4 && ANDROID_MINOR < 2)

--- a/droidmedia.h
+++ b/droidmedia.h
@@ -56,8 +56,9 @@ typedef struct {
 } DroidMediaRect;
 
 typedef struct {
+  bool (* buffer_created)(void *data, DroidMediaBuffer *buffer);
+  bool (* frame_available)(void *data, DroidMediaBuffer *buffer);
   void (* buffers_released)(void *data);
-  void (* frame_available)(void *data);
 } DroidMediaBufferQueueCallbacks;
 
 typedef struct {
@@ -83,14 +84,8 @@ void droid_media_init();
 void droid_media_deinit();
 
 /* droidmediabuffer.cpp */
-DroidMediaBuffer *droid_media_buffer_create_from_raw_data(uint32_t w, uint32_t h,
-							  uint32_t strideY, uint32_t strideUV,
-							  uint32_t format,
-							  DroidMediaData *data,
-							  DroidMediaBufferCallbacks *cb);
 DroidMediaBuffer *droid_media_buffer_create(uint32_t w, uint32_t h,
-					    uint32_t format,
-					    DroidMediaBufferCallbacks *cb);
+                                            uint32_t format);
 void *droid_media_buffer_lock(DroidMediaBuffer *buffer, uint32_t flags);
 void droid_media_buffer_unlock(DroidMediaBuffer *buffer);
 
@@ -104,14 +99,17 @@ uint32_t droid_media_buffer_get_width(DroidMediaBuffer * buffer);
 uint32_t droid_media_buffer_get_height(DroidMediaBuffer * buffer);
 const void *droid_media_buffer_get_handle(DroidMediaBuffer *buffer);
 void droid_media_buffer_release(DroidMediaBuffer *buffer,
-				EGLDisplay display, EGLSyncKHR fence);
+                                EGLDisplay display, EGLSyncKHR fence);
+void droid_media_buffer_destroy(DroidMediaBuffer *buffer);
+void droid_media_buffer_set_user_data(DroidMediaBuffer *buffer, void *data);
+void *droid_media_buffer_get_user_data(DroidMediaBuffer *buffer);
+
+
 
 /* private.h */
-DroidMediaBuffer *droid_media_buffer_queue_acquire_buffer(DroidMediaBufferQueue *queue,
-							  DroidMediaBufferCallbacks *cb);
 void droid_media_buffer_queue_set_callbacks(DroidMediaBufferQueue *queue,
 					    DroidMediaBufferQueueCallbacks *cb, void *data);
-bool droid_media_buffer_queue_acquire_and_release(DroidMediaBufferQueue *queue, DroidMediaBufferInfo *info);
+int droid_media_buffer_queue_length();
 
 #ifdef __cplusplus
 };

--- a/droidmediabuffer.h
+++ b/droidmediabuffer.h
@@ -23,23 +23,19 @@
 #include <gui/BufferQueue.h>
 #include "droidmedia.h"
 
+#if ANDROID_MAJOR >= 6
+typedef android::BufferItem DroidMediaBufferItem;
+#else
+typedef android::BufferQueue::BufferItem DroidMediaBufferItem;
+#endif
+
 struct _DroidMediaBuffer : public ANativeWindowBuffer
 {
 public:
-#if ANDROID_MAJOR < 6
-  _DroidMediaBuffer(android::BufferQueue::BufferItem& buffer,
-#else
-  _DroidMediaBuffer(android::BufferItem& buffer,
-#endif
-		   android::sp<DroidMediaBufferQueue> queue,
-		   void *data,
-		   DroidMediaCallback ref,
-		   DroidMediaCallback unref);
+  _DroidMediaBuffer(DroidMediaBufferItem& buffer,
+                   android::sp<DroidMediaBufferQueue> queue);
 
-  _DroidMediaBuffer(android::sp<android::GraphicBuffer>& buffer,
-		   void *data,
-		   DroidMediaCallback ref,
-		   DroidMediaCallback unref);
+  _DroidMediaBuffer(android::sp<android::GraphicBuffer>& buffer);
 
   ~_DroidMediaBuffer();
 
@@ -49,6 +45,7 @@ public:
   android::sp<android::GraphicBuffer> m_buffer;
   android::sp<DroidMediaBufferQueue> m_queue;
 
+  mutable volatile int32_t m_refCount;
   uint32_t m_transform;
   uint32_t m_scalingMode;
   int64_t m_timestamp;
@@ -57,9 +54,8 @@ public:
   android::Rect m_crop;
 
   int m_slot;
-  void *m_data;
-  DroidMediaCallback m_ref;
-  DroidMediaCallback m_unref;
+  void *m_userData;
+
 };
 
 #endif /* DROID_MEDIA_BUFFER_H */

--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -293,14 +293,11 @@ bool droid_media_camera_get_info(DroidMediaCameraInfo *info, int camera_number)
 
 DroidMediaCamera *droid_media_camera_connect(int camera_number)
 {
-    android::sp<DroidMediaBufferQueueListener> listener(new DroidMediaBufferQueueListener);
-
     android::sp<DroidMediaBufferQueue>
       queue(new DroidMediaBufferQueue("DroidMediaCameraBufferQueue"));
+    android::sp<DroidMediaBufferQueueListener> listener(new DroidMediaBufferQueueListener(queue.get()));
     if (!queue->connectListener()) {
         ALOGE("Failed to connect buffer queue listener");
-        queue.clear();
-        listener.clear();
         return NULL;
     }
 

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -797,6 +797,9 @@ void droid_media_codec_stop(DroidMediaCodec *codec)
         ALOGE("error 0x%x stopping codec", -err);
     }
 
+    if (codec->m_queue.get()) {
+        codec->m_queue->buffersReleased();
+     }
 }
 
 void droid_media_codec_destroy(DroidMediaCodec *codec)
@@ -881,6 +884,7 @@ DroidMediaCodecLoopReturn droid_media_codec_loop(DroidMediaCodec *codec)
 	    return DROID_MEDIA_CODEC_LOOP_EOS;
         } else {
             ALOGE("Error 0x%x reading from codec", -err);
+
             if (codec->m_cb.error) {
                 codec->m_cb.error(codec->m_cb_data, err);
             }

--- a/hybris.c
+++ b/hybris.c
@@ -178,16 +178,18 @@ HYBRIS_WRAPPER_1_2(bool, DroidMediaCamera*,const char *,droid_media_camera_set_p
 HYBRIS_WRAPPER_1_1(char *, DroidMediaCamera*, droid_media_camera_get_parameters)
 HYBRIS_WRAPPER_1_2(bool, DroidMediaCamera*, int, droid_media_camera_take_picture)
 HYBRIS_WRAPPER_1_1(DroidMediaBufferQueue*, DroidMediaCamera*, droid_media_camera_get_buffer_queue)
+HYBRIS_WRAPPER_0_1(DroidMediaBuffer*,droid_media_buffer_destroy)
 HYBRIS_WRAPPER_0_3(DroidMediaBuffer*,EGLDisplay,EGLSyncKHR,droid_media_buffer_release)
 HYBRIS_WRAPPER_0_2(DroidMediaCamera*, DroidMediaCameraRecordingData*,droid_media_camera_release_recording_frame)
 HYBRIS_WRAPPER_1_1(nsecs_t,DroidMediaCameraRecordingData*,droid_media_camera_recording_frame_get_timestamp)
 HYBRIS_WRAPPER_1_1(size_t,DroidMediaCameraRecordingData*,droid_media_camera_recording_frame_get_size)
 HYBRIS_WRAPPER_1_1(void*,DroidMediaCameraRecordingData*,droid_media_camera_recording_frame_get_data)
 HYBRIS_WRAPPER_1_3(bool,DroidMediaCamera*,DroidMediaCameraFaceDetectionType,bool,droid_media_camera_enable_face_detection)
-HYBRIS_WRAPPER_1_7(DroidMediaBuffer*,uint32_t,uint32_t,uint32_t,uint32_t,uint32_t,DroidMediaData*,DroidMediaBufferCallbacks*,droid_media_buffer_create_from_raw_data)
-HYBRIS_WRAPPER_1_4(DroidMediaBuffer*,uint32_t,uint32_t,uint32_t,DroidMediaBufferCallbacks*,droid_media_buffer_create)
+HYBRIS_WRAPPER_1_3(DroidMediaBuffer*,uint32_t,uint32_t,uint32_t,droid_media_buffer_create)
 HYBRIS_WRAPPER_1_2(void*,DroidMediaBuffer*,uint32_t,droid_media_buffer_lock)
 HYBRIS_WRAPPER_0_1(DroidMediaBuffer*,droid_media_buffer_unlock)
+HYBRIS_WRAPPER_0_2(DroidMediaBuffer*,void *,droid_media_buffer_set_user_data)
+HYBRIS_WRAPPER_1_1(void*,DroidMediaBuffer*,droid_media_buffer_get_user_data)
 HYBRIS_WRAPPER_0_2(DroidMediaBuffer*,DroidMediaBufferInfo*,droid_media_buffer_get_info)
 HYBRIS_WRAPPER_1_1(uint32_t,DroidMediaBuffer*,droid_media_buffer_get_transform)
 HYBRIS_WRAPPER_1_1(uint32_t,DroidMediaBuffer*,droid_media_buffer_get_scaling_mode)
@@ -197,6 +199,7 @@ HYBRIS_WRAPPER_1_1(DroidMediaRect,DroidMediaBuffer*,droid_media_buffer_get_crop_
 HYBRIS_WRAPPER_1_1(uint32_t,DroidMediaBuffer*,droid_media_buffer_get_width);
 HYBRIS_WRAPPER_1_1(uint32_t,DroidMediaBuffer*,droid_media_buffer_get_height);
 HYBRIS_WRAPPER_1_1(const void*,DroidMediaBuffer*,droid_media_buffer_get_handle);
+HYBRIS_WRAPPER_1_0(int,droid_media_buffer_queue_length);
 HYBRIS_WRAPPER_1_1(DroidMediaCodec*,DroidMediaCodecDecoderMetaData*,droid_media_codec_create_decoder);
 HYBRIS_WRAPPER_1_1(DroidMediaCodec*,DroidMediaCodecEncoderMetaData*,droid_media_codec_create_encoder);
 HYBRIS_WRAPPER_1_2(bool,DroidMediaCodecMetaData*,bool,droid_media_codec_is_supported);


### PR DESCRIPTION
We'd like to cache some buffer data on the receiving end and need
something persistent to link that too.