### PR TITLE
droidmedia: Fix build since android-9.0.0_r60

### DIFF
--- a/services/services_9_0_0.h
+++ b/services/services_9_0_0.h
@@ -164,6 +164,10 @@ public:
     status_t getLayerDebugInfo(std::vector<LayerDebugInfo>*) const {
         return 0;
     }
+
+    status_t getLayerDebugInfo(std::vector<LayerDebugInfo>*) {
+        return 0;
+    }
 };
 
 #include <binder/IPermissionController.h>


### PR DESCRIPTION
A week or so ago upstream removed the `const` qualifier from `getLayerDebugInfo()` which breaks our build if we don't update this as well.

To keep compatability with HAL not based on 9.0.0_r60 (such as Sony AOSP Hybris) we'll just duplicate the method instead, removing the `const` qualifier as per upstream.

Thanks to @NotKit for looking into this! :)

Reference:
https://github.com/LineageOS/android_frameworks_native/commit/23a8ea7cd2aa38cc28d37ae0e1e06043ec5da0b3