### PR TITLE
[droidmedia] Fix build with MediaTek Android 9.0.0. JB#52430

### DIFF
--- a/services/services_9_0_0.h
+++ b/services/services_9_0_0.h
@@ -133,6 +133,12 @@ public:
 
     status_t captureScreen(const sp<IBinder>&,
             sp<GraphicBuffer>*, bool&, Rect, uint32_t, uint32_t,
+            int32_t, int32_t, bool, Rotation) {
+        return BAD_VALUE;
+    }
+
+    status_t captureScreen(const sp<IBinder>&,
+            sp<GraphicBuffer>*, bool&, Rect, uint32_t, uint32_t,
             int32_t, int32_t, bool, Rotation, bool) {
         return BAD_VALUE;
     }


### PR DESCRIPTION
MediaTek has changed ISurfaceComposer in its Android 9 BSP, so droidmedia
doesn't compile without this commit.