### PR TITLE
[droidmedia] Add missing include for audio policy build in Android 10.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -138,6 +138,10 @@ LOCAL_C_INCLUDES += frameworks/av/services/audiopolicy \
                     frameworks/av/services/audiopolicy/managerdefault \
                     frameworks/av/services/audiopolicy/service
 endif
+ifeq ($(shell test $(ANDROID_MAJOR) -ge 10 && echo true),true)
+LOCAL_C_INCLUDES += frameworks/av/media/utils/include
+endif
+
 LOCAL_SHARED_LIBRARIES += libaudiopolicyservice
 endif
 


### PR DESCRIPTION
Change-Id: I5b4cb19ce3203843f1edd35bb3b228ff29da2739