### PR TITLE
[droidmedia] Add some checks for null pointer. Fixes JB#53621

### DIFF
--- a/AsyncDecodingSource.cpp
+++ b/AsyncDecodingSource.cpp
@@ -70,20 +70,25 @@ sp<AsyncDecodingSource> AsyncDecodingSource::Create(
         ALOGV("Attempting to allocate codec '%s'", componentName.c_str());
         sp<AsyncDecodingSource> res = new AsyncDecodingSource(componentName, source, looper,
                         strcmp(mime, MEDIA_MIMETYPE_AUDIO_VORBIS) == 0);
-        ALOGI("Successfully allocated codec '%s'", componentName.c_str());
 
-        if (res->configure(format, surface, 0)) {
-            if (surface != nullptr) {
+        if (res->mCodec != NULL) {
+            ALOGI("Successfully allocated codec '%s'", componentName.c_str());
+            if (res->configure(format, surface, 0)) {
+                if (surface != nullptr) {
 #if ANDROID_MAJOR > 7
-                nativeWindowConnect(nativeWindow.get(), "AsyncDecodingSource");
+                    nativeWindowConnect(nativeWindow.get(), "AsyncDecodingSource");
 #else
-                native_window_api_connect(nativeWindow.get(),
-                                              NATIVE_WINDOW_API_MEDIA);
+                    native_window_api_connect(nativeWindow.get(),
+                                                NATIVE_WINDOW_API_MEDIA);
 #endif
+                }
+                return res;
+            } else {
+                ALOGE("Failed to configure codec '%s'", componentName.c_str());
             }
-            return res;
-        } else {
-            ALOGE("Failed to configure codec '%s'", componentName.c_str());
+        }
+        else {
+            ALOGE("Failed to allocate codec '%s'", componentName.c_str());
         }
     }
 

--- a/private.cpp
+++ b/private.cpp
@@ -283,7 +283,9 @@ extern "C" {
 void droid_media_buffer_queue_set_callbacks(DroidMediaBufferQueue *queue,
     DroidMediaBufferQueueCallbacks *cb, void *data) {
 
-  return queue->setCallbacks(cb, data);
+  if (queue) {
+    queue->setCallbacks(cb, data);
+  }
 }
 
 int droid_media_buffer_queue_length() {


### PR DESCRIPTION
The problem is that multimedia breaks after attempt to play
5 static video in browser simultaneously. It seems that Android have
a limitation of use for 4 hardware decoders at the same time, for example
in logcat:

E osal_utils: Returns insufficientResource
E media.codec: Failed to allocate omx component 'OMX.MTK.VIDEO.DECODER.AVC'
               err=InsufficientResources(0x80001000)

We need to add checking for null pointer after calling AsyncDecodingSource
constructor in Create method. We call in constructor
mCodec = MediaCodec::CreateByComponentName(mCodecLooper, mComponentName);
and in Android it can return NULL for some reasons, for example when we
try to use 5 hardware decoders simultaneously

const status_t ret = codec->init(name);
if (err != NULL) {
    *err = ret;
}
return ret == OK ? codec : NULL; // NULL deallocates codec.

So we should check res->mCodec for NULL.

Also we should check queue for null pointer because in finalization case
DroidmediaBufferQueue is already destructed, but we catch a call
droid_media_buffer_queue_set_callbacks from Android side.