### PR TITLE
[droidmedia] Add control over codec specific settings for avc encoder. JB#54553

### DIFF
--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -454,9 +454,24 @@ public:
 #endif
 
       if (!strcmp (mime, android::MEDIA_MIMETYPE_VIDEO_AVC)) {
-        format->setInt32("profile", OMX_VIDEO_AVCProfileBaseline);
-        int32_t level = android::ACodec::getAVCLevelFor(width, height, frames, bitrate);
+        int32_t profile = m_enc->codec_specific.h264.profile;
+        int32_t level = m_enc->codec_specific.h264.level;
+
+        if (!profile) {
+          profile = OMX_VIDEO_AVCProfileBaseline;
+        }
+
+        if (!level) {
+          level = android::ACodec::getAVCLevelFor(width, height, frames, bitrate,
+                                                  (OMX_VIDEO_AVCPROFILEEXTTYPE)profile);
+        }
+
+        format->setInt32("profile", profile);
         format->setInt32("level", level);
+
+        if (m_enc->codec_specific.h264.prepend_header_to_sync_frames) {
+          format->setInt32("prepend-sps-pps-to-idr-frames", 1);
+        }
       }
       //TODO: time-scale
 

--- a/droidmediacodec.h
+++ b/droidmediacodec.h
@@ -60,6 +60,12 @@ typedef struct {
   DroidMediaData codec_data;
 } DroidMediaCodecDecoderMetaData;
 
+typedef struct DroidMediaCodecEncoderH264Settings {
+  int32_t profile;
+  int32_t level;
+  int32_t prepend_header_to_sync_frames;
+} DroidMediaCodecEncoderH264Settings;
+
 typedef struct {
   DroidMediaCodecMetaData parent;
 
@@ -69,6 +75,9 @@ typedef struct {
   int32_t stride;
   int32_t slice_height;
   int32_t max_input_size;
+  union {
+    DroidMediaCodecEncoderH264Settings h264;
+  } codec_specific;
 } DroidMediaCodecEncoderMetaData;
 
 typedef struct {


### PR DESCRIPTION
The "prepend-sps-pps-to-idr-frames" metadata key is required to produce h264 video suitable for streaming.