### PR TITLE
[droidmedia] Fix build for droid versions < 8.1. JB#54553

### DIFF
--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -463,7 +463,11 @@ public:
 
         if (!level) {
           level = android::ACodec::getAVCLevelFor(width, height, frames, bitrate,
+#if (ANDROID_MAJOR == 8 && ANDROID_MINOR >= 1) || ANDROID_MAJOR >= 9
                                                   (OMX_VIDEO_AVCPROFILEEXTTYPE)profile);
+#else
+                                                  (OMX_VIDEO_AVCPROFILETYPE)profile);
+#endif
         }
 
         format->setInt32("profile", profile);


### PR DESCRIPTION
ACodec::getAVCLevelFor profile parameter was changed from OMX_VIDEO_AVCPROFILETYPE to OMX_VIDEO_AVCPROFILEEXTTYPE in 8.1