### PR TITLE
[droidmedia] Split the droidmedia package. JB#54878

### DIFF
--- a/droidmedia.cpp
+++ b/droidmedia.cpp
@@ -23,11 +23,8 @@
 
 extern "C" {
 
-void droid_media_init()
+void _droid_media_init()
 {
-
-
-
     android::ProcessState::self()->startThreadPool();
 }
 

--- a/droidmedia.h
+++ b/droidmedia.h
@@ -80,7 +80,7 @@ typedef enum {
 } DroidMediaBufferLockFlags;
 
 /* droidmedia.cpp */
-void droid_media_init();
+bool droid_media_init();
 void droid_media_deinit();
 
 /* droidmediabuffer.cpp */

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,38 @@
+project(
+  'droidmedia', 'c',
+  default_options : ['warning_level=1', 'buildtype=debugoptimized'],
+)
+
+droidmedia_version = meson.project_version()
+droidmedia = meson.project_name()
+
+cc = meson.get_compiler('c')
+
+root_dir = include_directories('.')
+
+droidmedia_source = [
+  'hybris.c',
+]
+
+libdroidmedia_a = static_library('droidmedia',
+                                 droidmedia_source,
+                                 install: true,
+                                 dependencies: cc.find_library('dl', required : true))
+
+droidmedia_headers = [
+    'droidmediabuffer.h',
+    'droidmediacamera.h',
+    'droidmediacodec.h',
+    'droidmediaconstants.h',
+    'droidmediaconvert.h',
+    'droidmedia.h',
+    'droidmediarecorder.h'
+]
+
+install_headers(droidmedia_headers, subdir : meson.project_name())
+install_data('hybris.c', install_dir : get_option('datadir') / meson.project_name())
+
+pkg = import('pkgconfig')
+pkg.generate(libdroidmedia_a,
+             libraries: ['-ldl'],
+             subdirs: ['droidmedia'])

--- a/rpm/droidmedia-devel.spec
+++ b/rpm/droidmedia-devel.spec
@@ -1,0 +1,31 @@
+Name:          droidmedia-devel
+Summary:       Android media wrapper library development package
+Version:       0.20170214.0
+Release:       1
+License:       ASL 2.0
+Source0:       %{name}-%{version}.tgz
+BuildRequires: meson
+BuildRequires: ninja
+Suggests:      libhybris
+Suggests:      droidmedia = %{version}-%{release}
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%build
+%meson -Dversion=%{version}-%{release}
+meson rewrite kwargs set project / version %{version}-%{release}
+%meson_build
+
+%install
+%meson_install
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/libdroidmedia.a
+%{_includedir}/droidmedia/*.h
+%{_datadir}/droidmedia/hybris.c
+%{_libdir}/pkgconfig/droidmedia.pc

--- a/rpm/droidmedia.spec
+++ b/rpm/droidmedia.spec
@@ -24,7 +24,6 @@ Name:          droidmedia
 Summary:       Android media wrapper library
 Version:       0.20170214.0
 Release:       1
-Group:         System/Libraries
 License:       ASL 2.0
 BuildRequires: ubu-trusty
 BuildRequires: sudo-for-abuild
@@ -33,14 +32,6 @@ Source0:       %{name}-%{version}.tgz
 AutoReqProv:   no
 
 %description
-%{summary}
-
-%package       devel
-Summary:       droidmedia development headers
-Requires:      droidmedia = %{version}-%{release}
-BuildArch:     noarch
-
-%description   devel
 %{summary}
 
 %prep
@@ -81,8 +72,6 @@ fi
 
 mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
 mkdir -p $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
-mkdir -p $RPM_BUILD_ROOT/%{_includedir}/droidmedia/
-mkdir -p $RPM_BUILD_ROOT/%{_datadir}/droidmedia/
 
 cp out/target/product/*/system/$DROIDLIB/libdroidmedia.so \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/$DROIDLIB/
@@ -96,9 +85,6 @@ cp out/target/product/*/system/bin/minimediaservice \
 cp out/target/product/*/system/bin/minisfservice \
     $RPM_BUILD_ROOT/%{_libexecdir}/droid-hybris/system/bin/
 
-cp external/droidmedia/*.h $RPM_BUILD_ROOT/%{_includedir}/droidmedia/
-cp external/droidmedia/hybris.c $RPM_BUILD_ROOT/%{_datadir}/droidmedia/
-
 LIBDMSOLOC=$RPM_BUILD_ROOT/file.list
 echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libdroidmedia.so >> %{LIBDMSOLOC}
 echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libminisf.so >> %{LIBDMSOLOC}
@@ -107,8 +93,3 @@ echo %{_libexecdir}/droid-hybris/system/$DROIDLIB/libminisf.so >> %{LIBDMSOLOC}
 %defattr(-,root,root,-)
 %{_libexecdir}/droid-hybris/system/bin/minimediaservice
 %{_libexecdir}/droid-hybris/system/bin/minisfservice
-
-%files devel
-%defattr(-,root,root,-)
-%{_includedir}/droidmedia/*.h
-%{_datadir}/droidmedia/hybris.c


### PR DESCRIPTION
Split the droidmedia-devel package into its own spec file named
droidmedia-lib. It can be built in hadware-independent projects and
applications may link against droidmedia using pkgconfig.