### PR TITLE
[droidmedia] Query the list of supported color formats. JB#55092

### DIFF
--- a/droidmediacodec.h
+++ b/droidmediacodec.h
@@ -102,6 +102,8 @@ DroidMediaBufferQueue *droid_media_codec_get_buffer_queue (DroidMediaCodec *code
 DroidMediaCodec *droid_media_codec_create_decoder(DroidMediaCodecDecoderMetaData *meta);
 DroidMediaCodec *droid_media_codec_create_encoder(DroidMediaCodecEncoderMetaData *meta);
 bool droid_media_codec_is_supported(DroidMediaCodecMetaData *meta, bool encoder);
+unsigned int droid_media_codec_get_supported_color_formats(const char *mime, int encoder,
+							   uint32_t *formats, unsigned maxFormats);
 
 void droid_media_codec_set_callbacks(DroidMediaCodec *codec, DroidMediaCodecCallbacks *cb, void *data);
 void droid_media_codec_set_data_callbacks(DroidMediaCodec *codec,

--- a/hybris.c
+++ b/hybris.c
@@ -225,6 +225,7 @@ HYBRIS_WRAPPER_1_0(int,droid_media_buffer_queue_length);
 HYBRIS_WRAPPER_1_1(DroidMediaCodec*,DroidMediaCodecDecoderMetaData*,droid_media_codec_create_decoder);
 HYBRIS_WRAPPER_1_1(DroidMediaCodec*,DroidMediaCodecEncoderMetaData*,droid_media_codec_create_encoder);
 HYBRIS_WRAPPER_1_2(bool,DroidMediaCodecMetaData*,bool,droid_media_codec_is_supported);
+HYBRIS_WRAPPER_1_4(unsigned,const char*,int,uint32_t*,unsigned,droid_media_codec_get_supported_color_formats);
 HYBRIS_WRAPPER_1_1(bool,DroidMediaCodec*,droid_media_codec_start);
 HYBRIS_WRAPPER_0_1(DroidMediaCodec*,droid_media_codec_stop);
 HYBRIS_WRAPPER_0_1(DroidMediaCodec *,droid_media_codec_destroy);


### PR DESCRIPTION
This commit adds droid_media_codec_get_supported_color_formats() which
is useful for implementing a video encoder: the color format of the input
video frame must be converted to match the capabilities of the codec.