### PR TITLE
[droidmedia] Fix 64 bit build. JB#55092

### DIFF
--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -766,7 +766,7 @@ bool droid_media_codec_is_supported(DroidMediaCodecMetaData *meta, bool encoder)
     return matchingCodecs.size() > 0;
 }
 
-unsigned int droid_media_codec_get_supported_color_formats(const char *mime, int encoder, uint32_t *formats, unsigned maxFormats)
+unsigned int droid_media_codec_get_supported_color_formats(const char *mime, int encoder, uint32_t *formats, unsigned int maxFormats)
 {
     android::sp<android::MediaCodecList::IMediaCodecList> list = android::MediaCodecList::getInstance();
     int index = 0;
@@ -779,8 +779,8 @@ unsigned int droid_media_codec_get_supported_color_formats(const char *mime, int
             if (caps != nullptr) {
                 android::Vector<uint32_t> colorFormats;
                 caps->getSupportedColorFormats(&colorFormats);
-                maxFormats = std::min(maxFormats, colorFormats.size());
-                for (unsigned i = 0; i < maxFormats; i++) {
+                maxFormats = std::min<unsigned int>(maxFormats, colorFormats.size());
+                for (unsigned int i = 0; i < maxFormats; i++) {
                     formats[i] = colorFormats.itemAt(i);
                 }
                 return maxFormats;

--- a/droidmediacodec.h
+++ b/droidmediacodec.h
@@ -103,7 +103,7 @@ DroidMediaCodec *droid_media_codec_create_decoder(DroidMediaCodecDecoderMetaData
 DroidMediaCodec *droid_media_codec_create_encoder(DroidMediaCodecEncoderMetaData *meta);
 bool droid_media_codec_is_supported(DroidMediaCodecMetaData *meta, bool encoder);
 unsigned int droid_media_codec_get_supported_color_formats(const char *mime, int encoder,
-							   uint32_t *formats, unsigned maxFormats);
+                               uint32_t *formats, unsigned int maxFormats);
 
 void droid_media_codec_set_callbacks(DroidMediaCodec *codec, DroidMediaCodecCallbacks *cb, void *data);
 void droid_media_codec_set_data_callbacks(DroidMediaCodec *codec,


### PR DESCRIPTION
The type of colorFormats.size() varies by architecture but maxFormats
doesn't, be explicit about the type of the min function so it compiles
when the implicit types don't match.