### PR TITLE
[droidmedia] Use recorder callback for Android 8. Fixes JB#55656

### DIFF
--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -341,7 +341,7 @@ DroidMediaCamera *droid_media_camera_connect(int camera_number)
     cam->m_queue = queue;
     cam->m_queue->attachToCameraPreview(cam->m_camera);
 
-#if ANDROID_MAJOR >= 8
+#if ANDROID_MAJOR >= 9
     android::sp<DroidMediaBufferQueue>
       recording_queue(new DroidMediaBufferQueue("DroidMediaCameraBufferRecordingQueue"));
     if (!recording_queue->connectListener()) {
@@ -369,7 +369,7 @@ void droid_media_camera_disconnect(DroidMediaCamera *camera)
 
     camera->m_queue->setCallbacks(0, 0);
 
-#if ANDROID_MAJOR >= 8
+#if ANDROID_MAJOR >= 9
     if (camera->m_recording_queue.get()) {
       camera->m_recording_queue->setCallbacks(0, 0);
     }

--- a/private.cpp
+++ b/private.cpp
@@ -129,7 +129,7 @@ void _DroidMediaBufferQueue::attachToCameraPreview(android::sp<android::Camera>&
 }
 
 void _DroidMediaBufferQueue::attachToCameraVideo(android::sp<android::Camera>& camera) {
-#if ANDROID_MAJOR >= 8
+#if ANDROID_MAJOR >= 9
     camera->setVideoTarget(m_producer);
 #endif
 }


### PR DESCRIPTION
The camera on Android 8 does have setVideoTarget() method but it doesn't
work as expected, so droidmedia should use recorder callback instead of
buffer queue mode to capture raw video frames.