### PR TITLE
[droidmedia] Set the depth of the decoder input queue. JB#56100

### DIFF
--- a/AsyncDecodingSource.cpp
+++ b/AsyncDecodingSource.cpp
@@ -62,6 +62,8 @@ sp<AsyncDecodingSource> AsyncDecodingSource::Create(
         return nullptr;
     }
 
+    format->setInt32("android._num-input-buffers", 12);
+
     Vector<AString> matchingCodecs;
     MediaCodecList::findMatchingCodecs(
             mime, false /* encoder */, flags, &matchingCodecs);


### PR DESCRIPTION
On MediaTek devices, the default decoder input queue depth is insufficient
in some situations. The starvation of the buffer queue leads to a freeze
in the playback of some AVC-encoded videos.

This commit sets an empirically chosen value for the decoder input queue.