### PR TITLE
[droidmedia] Fix build for droid versions < 5. JB#56755

### DIFF
--- a/droidmediaconstants.cpp
+++ b/droidmediaconstants.cpp
@@ -97,7 +97,12 @@ void droid_media_colour_format_constants_init(DroidMediaColourFormatConstants *c
   c->OMX_COLOR_Format32bitBGRA8888 = OMX_COLOR_Format32bitBGRA8888;
   c->OMX_COLOR_Format16bitRGB565 = OMX_COLOR_Format16bitRGB565;
   c->OMX_COLOR_Format16bitBGR565 = OMX_COLOR_Format16bitBGR565;
+#if ANDROID_MAJOR >= 5
   c->OMX_COLOR_FormatYUV420Flexible = OMX_COLOR_FormatYUV420Flexible;
+#else
+  // OMX_COLOR_FormatUnused = 0
+  c->OMX_COLOR_FormatYUV420Flexible = OMX_COLOR_FormatUnused;
+#endif
 }
 
 };


### PR DESCRIPTION
OMX_COLOR_FormatYUV420Flexible appeared in android 5 so export
this constant as equal to OMX_COLOR_FormatUnused for older versions.