### PR TITLE
[droidmedia] Add encoder setting for CBR/VBR. JB#57733

### DIFF
--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -477,6 +477,10 @@ public:
         if (m_enc->codec_specific.h264.prepend_header_to_sync_frames) {
           format->setInt32("prepend-sps-pps-to-idr-frames", 1);
         }
+
+        if (m_enc->bitrate_mode != DROID_MEDIA_CODEC_BITRATE_CONTROL_DEFAULT) {
+          format->setInt32("bitrate-mode", m_enc->bitrate_mode);
+        }
       }
       //TODO: time-scale
 

--- a/droidmediacodec.h
+++ b/droidmediacodec.h
@@ -43,6 +43,13 @@ typedef enum {
   DROID_MEDIA_CODEC_LOOP_EOS,
 } DroidMediaCodecLoopReturn;
 
+/* See OMX_VIDEO_CONTROLRATETYPE */
+typedef enum {
+  DROID_MEDIA_CODEC_BITRATE_CONTROL_DEFAULT = 0,
+  DROID_MEDIA_CODEC_BITRATE_CONTROL_VBR = 1,
+  DROID_MEDIA_CODEC_BITRATE_CONTROL_CBR = 2,
+} DroidMediaCodecBitrateMode;
+
 typedef struct {
   const char *type;
   int32_t width;
@@ -76,6 +83,7 @@ typedef struct {
   int32_t stride;
   int32_t slice_height;
   int32_t max_input_size;
+  int32_t bitrate_mode;
   union {
     DroidMediaCodecEncoderH264Settings h264;
   } codec_specific;


### PR DESCRIPTION
This commit adds bitrate_mode to the encoder metadata that controls
the video encoder's bitrate control mode. Set this field to 0 or
DROID_MEDIA_CODEC_BITRATE_CONTROL_DEFAULT to keep the default bitrate
mode, which is usually VBR.