### PR TITLE
[droidmedia] Fix build for droid versions < 7. JB#57676

### DIFF
--- a/AsyncCodecSource.h
+++ b/AsyncCodecSource.h
@@ -32,14 +32,9 @@
 #include <utils/Condition.h>
 #include <utils/StrongPointer.h>
 
-struct ANativeWindow;
+#include "mediabuffers.h"
 
-template<typename T>
-struct Buffers {
-    android::List<T>buffers;
-    android::Condition cond;
-    android::Mutex lock;
-};
+struct ANativeWindow;
 
 namespace android {
 

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -38,6 +38,8 @@
 #include <media/stagefright/foundation/AMessage.h>
 #endif
 
+#include "mediabuffers.h"
+
 #if ANDROID_MAJOR < 7
 #include <media/stagefright/OMXCodec.h>
 #else

--- a/mediabuffers.h
+++ b/mediabuffers.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Jolla Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#ifndef MEDIA_BUFFERS_H_
+#define MEDIA_BUFFERS_H_
+
+#include <utils/Condition.h>
+#include <utils/List.h>
+
+template<typename T>
+struct Buffers {
+    android::List<T>buffers;
+    android::Condition cond;
+    android::Mutex lock;
+};
+
+#endif


### PR DESCRIPTION
Define Buffers in a separate header so that older than Android 7 devices can include buffers separately from the ASyncCodecSource (see droidmediacodec.cpp).

Regression from SHA1 97662efa2bf0d7a800270805a945d3f4717b9a3b