### PR TITLE
Buffers are not always recycled automatically

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -118,12 +118,6 @@ ifeq ($(ANDROID_MAJOR),$(filter $(ANDROID_MAJOR),9))
 LOCAL_C_INCLUDES += frameworks/av/media/libmediaextractor/include
 endif
 
-ifeq ($(shell test $(ANDROID_MAJOR) -le 5 && echo true),true)
-LOCAL_CPPFLAGS += -std=c++11
-LOCAL_SHARED_LIBRARIES += libc++
-LOCAL_C_INCLUDES += external/libcxx/include
-endif
-
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)

--- a/Android.mk
+++ b/Android.mk
@@ -119,7 +119,7 @@ LOCAL_C_INCLUDES += frameworks/av/media/libmediaextractor/include
 endif
 
 ifeq ($(shell test $(ANDROID_MAJOR) -le 5 && echo true),true)
-LOCAL_CPPFLAGS += --std=c++11
+LOCAL_CPPFLAGS += -std=c++11
 endif
 
 include $(BUILD_SHARED_LIBRARY)

--- a/Android.mk
+++ b/Android.mk
@@ -120,6 +120,8 @@ endif
 
 ifeq ($(shell test $(ANDROID_MAJOR) -le 5 && echo true),true)
 LOCAL_CPPFLAGS += -std=c++11
+LOCAL_SHARED_LIBRARIES += libc++
+LOCAL_C_INCLUDES += external/libcxx/include
 endif
 
 include $(BUILD_SHARED_LIBRARY)

--- a/Android.mk
+++ b/Android.mk
@@ -118,6 +118,10 @@ ifeq ($(ANDROID_MAJOR),$(filter $(ANDROID_MAJOR),9))
 LOCAL_C_INCLUDES += frameworks/av/media/libmediaextractor/include
 endif
 
+ifeq ($(shell test $(ANDROID_MAJOR) -le 5 && echo true),true)
+LOCAL_CPPFLAGS += --std=c++11
+endif
+
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)

--- a/droidmediabuffer.cpp
+++ b/droidmediabuffer.cpp
@@ -133,9 +133,10 @@ void droid_media_buffer_destroy(DroidMediaBuffer *buffer)
     buffer->m_queue->releaseBufferResources(buffer);
     return;
   }
-  ALOGW("Decrementing buffer refs without a queue %" PRIxPTR, (uintptr_t)buffer);
-#endif
+  ALOGW("Destroying buffer refs but no queue %" PRIxPTR, (uintptr_t)buffer);
+#else
   buffer->decStrong(0);
+#endif
 }
 
 void droid_media_buffer_set_user_data(DroidMediaBuffer *buffer, void *data)

--- a/droidmediabuffer.cpp
+++ b/droidmediabuffer.cpp
@@ -128,12 +128,14 @@ DroidMediaBuffer *droid_media_buffer_create(uint32_t w, uint32_t h,
 
 void droid_media_buffer_destroy(DroidMediaBuffer *buffer)
 {
+#if ANDROID_MAJOR > 5
   if (buffer->m_queue != NULL) {
     buffer->m_queue->releaseBufferResources(buffer);
-  } else {
-    ALOGW("Decrementing buffer refs without a queue %" PRIxPTR, (uintptr_t)buffer);
-    buffer->decStrong(0);
+    return;
   }
+  ALOGW("Decrementing buffer refs without a queue %" PRIxPTR, (uintptr_t)buffer);
+#endif
+  buffer->decStrong(0);
 }
 
 void droid_media_buffer_set_user_data(DroidMediaBuffer *buffer, void *data)

--- a/droidmediabuffer.cpp
+++ b/droidmediabuffer.cpp
@@ -128,7 +128,7 @@ DroidMediaBuffer *droid_media_buffer_create(uint32_t w, uint32_t h,
 
 void droid_media_buffer_destroy(DroidMediaBuffer *buffer)
 {
-  if (buffer->m_queue) {
+  if (buffer->m_queue != NULL) {
     buffer->m_queue->releaseBufferResources(buffer);
   } else {
     ALOGW("Decrementing buffer refs without a queue %" PRIxPTR, (uintptr_t)buffer);

--- a/droidmediabuffer.cpp
+++ b/droidmediabuffer.cpp
@@ -17,6 +17,7 @@
  * Authored by: Mohammed Hassan <mohammed.hassan@jolla.com>
  */
 
+#include <inttypes.h>
 #include "droidmediabuffer.h"
 #include "private.h"
 
@@ -127,7 +128,12 @@ DroidMediaBuffer *droid_media_buffer_create(uint32_t w, uint32_t h,
 
 void droid_media_buffer_destroy(DroidMediaBuffer *buffer)
 {
-  buffer->decStrong(0);
+  if (buffer->m_queue) {
+    buffer->m_queue->releaseBufferResources(buffer);
+  } else {
+    ALOGW("Decrementing buffer refs without a queue %" PRIxPTR, (uintptr_t)buffer);
+    buffer->decStrong(0);
+  }
 }
 
 void droid_media_buffer_set_user_data(DroidMediaBuffer *buffer, void *data)

--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -181,7 +181,7 @@ public:
         for (android::List<android::MediaBuffer *>::iterator iter = m_framesBeingProcessed.buffers.begin();
              iter != m_framesBeingProcessed.buffers.end(); iter++) {
             if (*iter == buffer) {
-                m_framesBeingProcessed.buffers.erase(iter);                
+                m_framesBeingProcessed.buffers.erase(iter);
                 m_framesBeingProcessed.cond.signal();
                 m_framesBeingProcessed.lock.unlock();
                 return;

--- a/private.cpp
+++ b/private.cpp
@@ -179,6 +179,7 @@ void _DroidMediaBufferQueue::frameAvailable() {
       // It seems the buffers are not recycled. We're manually releasing this previous slot.
       ALOGW("Releasing only resources, keeping memory %" PRIxPTR, (uintptr_t)slot.droidBuffer.get());
       slot.mGraphicBuffer = 0;
+      slot.droidBuffer->m_buffer.clear();
       // instead of clear-ing the entire memory which leads to droid_media_buffer_destroy crashing.
       releaseBufferResources(slot.droidBuffer.get());
       // Add the buffer to the list of unslotted buffers that droid_media_buffer_destroy will check and don't do anything.
@@ -237,7 +238,6 @@ void _DroidMediaBufferQueue::releaseBufferResources(DroidMediaBuffer *buffer) {
     ALOGI("Unslotted buffer, resources already released %" PRIxPTR, (uintptr_t)buffer);
   } else {
     buffer->decStrong(0);
-    buffer->m_buffer.clear();
   }
 }
 #endif

--- a/private.cpp
+++ b/private.cpp
@@ -173,6 +173,12 @@ void _DroidMediaBufferQueue::frameAvailable() {
   if (item.mGraphicBuffer != NULL) {
     static_cast<DroidMediaBufferItem &>(slot) = item;
 
+    if (slot.droidBuffer.get()) {
+      // It seems the buffers are not recycled. We're manually releasing this previous slot.
+      slot.droidBuffer->decStrong(0);
+      // clear() is left for seeking/video end from clients like gecko-camera to not crash.
+    }
+
     slot.droidBuffer = new DroidMediaBuffer(slot, this);
 
     // Keep the original reference count for ourselves and give one to the buffer_created

--- a/private.cpp
+++ b/private.cpp
@@ -246,9 +246,9 @@ void _DroidMediaBufferQueue::buffersReleased() {
 
   // Releasing DroidMediaBuffer memory for slots
   for (int i = 0; i < android::BufferQueue::NUM_BUFFER_SLOTS; ++i) {
-      DroidMediaBufferSlot &slot = m_slots[i];
-      slot.droidBuffer.clear();
-      slot.mGraphicBuffer = 0;
+    DroidMediaBufferSlot &slot = m_slots[i];
+    slot.droidBuffer.clear();
+    slot.mGraphicBuffer = 0;
   }
   // Releasing DroidMediaBuffer memory for unslotted buffers
   for (auto& droidBufferPair : m_unslotted) {

--- a/private.h
+++ b/private.h
@@ -81,6 +81,8 @@ public:
 
   void buffersReleased();
 
+  void releaseBufferResources(DroidMediaBuffer *buffer);
+
 private:
   friend class DroidMediaBufferQueueListener;
 
@@ -97,6 +99,10 @@ private:
 
   DroidMediaBufferSlot m_slots[android::BufferQueue::NUM_BUFFER_SLOTS];
 
+  // Storage for buffers that have their resources cleaned up, but the client still holds a raw reference.
+  // The first part is used to identify the raw pointer from client, the second to actually clean the memory.
+  std::unordered_map<DroidMediaBuffer*, android::sp<DroidMediaBuffer>> m_unslotted;
+
   android::sp<DroidMediaBufferQueueListener> m_listener;
   android::Mutex m_lock;
 
@@ -111,5 +117,5 @@ android::sp<android::MediaSource> droid_media_codec_create_encoder_raw(DroidMedi
 							      android::sp<android::ALooper> looper,
 #endif
 							      android::sp<android::MediaSource> src);
- 
+
 #endif /* DROID_MEDIA_PRIVATE_H */

--- a/private.h
+++ b/private.h
@@ -33,6 +33,7 @@
 #if ANDROID_MAJOR >=5
 #include <media/stagefright/foundation/ALooper.h>
 #endif
+#include <unordered_map>
 
 struct _DroidMediaBufferQueue;
 

--- a/private.h
+++ b/private.h
@@ -33,8 +33,9 @@
 #if ANDROID_MAJOR >=5
 #include <media/stagefright/foundation/ALooper.h>
 #endif
+#if ANDROID_MAJOR > 5
 #include <unordered_map>
-
+#endif
 struct _DroidMediaBufferQueue;
 
 class DroidMediaBufferQueueListener :
@@ -82,8 +83,9 @@ public:
 
   void buffersReleased();
 
+#if ANDROID_MAJOR > 5
   void releaseBufferResources(DroidMediaBuffer *buffer);
-
+#endif
 private:
   friend class DroidMediaBufferQueueListener;
 
@@ -100,10 +102,11 @@ private:
 
   DroidMediaBufferSlot m_slots[android::BufferQueue::NUM_BUFFER_SLOTS];
 
+#if ANDROID_MAJOR > 5
   // Storage for buffers that have their resources cleaned up, but the client still holds a raw reference.
   // The first part is used to identify the raw pointer from client, the second to actually clean the memory.
   std::unordered_map<DroidMediaBuffer*, android::sp<DroidMediaBuffer>> m_unslotted;
-
+#endif
   android::sp<DroidMediaBufferQueueListener> m_listener;
   android::Mutex m_lock;
 


### PR DESCRIPTION
This was observed on asus sake, media buffers on, a lineage-18.1 port which uses media buffers: the mGraphicBuffer was not recycled (did not come null). The previous one from the slot needed to be unref'd.

The pointer itself is not, since clients are not aware of this change.

So a pointer tracking was introduced that allows clients to have `DroidMediaBuffer` pointers even if they are devoid of resources until the `releaseBuffers` call comes in which also clears the memory.