### PR TITLE
exposure: use locale independent float conversion

### DIFF
--- a/droidmediacamera2.cpp
+++ b/droidmediacamera2.cpp
@@ -1688,9 +1688,14 @@ char *droid_media_camera_get_parameters(DroidMediaCamera *camera)
             params += "min-exposure-compensation="+std::to_string(entry.data.i32[0])+";";
             params += "max-exposure-compensation="+std::to_string(entry.data.i32[1])+";";
             break;
-        case ACAMERA_CONTROL_AE_COMPENSATION_STEP:
-            params += "exposure-compensation-step="+std::to_string((float)entry.data.r[0].numerator / (float)entry.data.r[0].denominator)+";";
+        case ACAMERA_CONTROL_AE_COMPENSATION_STEP: {
+            // convert to string using no locale
+            std::ostringstream oss;
+            oss.imbue(std::locale::classic());
+            oss << "exposure-compensation-step=" << ((float)entry.data.r[0].numerator / (float)entry.data.r[0].denominator) << ";";
+            params += oss.str();
             break;
+        }
         case ACAMERA_CONTROL_AE_LOCK_AVAILABLE:
             if (entry.count > 0 || entry.data.u8[0] == ACAMERA_CONTROL_AE_LOCK_AVAILABLE_TRUE) {
                 params += "auto-exposure-lock-supported=true;";

--- a/droidmediacamera2.cpp
+++ b/droidmediacamera2.cpp
@@ -1770,8 +1770,8 @@ char *droid_media_camera_get_parameters(DroidMediaCamera *camera)
             break;
         case ACAMERA_CONTROL_MAX_REGIONS:
             if (entry.count > 0) {
-                 params += "max-num-focus-areas"+std::to_string(entry.data.u8[2])+";";
-                 params += "max-num-metering-areas"+std::to_string(entry.data.u8[0])+";";
+                 params += "max-num-focus-areas="+std::to_string(entry.data.u8[2])+";";
+                 params += "max-num-metering-areas="+std::to_string(entry.data.u8[0])+";";
                  camera->max_ae_regions = entry.data.u8[0];
                  camera->max_awb_regions = entry.data.u8[1];
                  camera->max_focus_regions = entry.data.u8[2];


### PR DESCRIPTION
`std::to_string` (and the inverse `std::stod`) will use the active `c` locale. Qt apps do this somewhere deep inside. This resulted in the step size being printed as "0,166", which was parsed by the consumer as "0" on systems using `,` as decimal separator (eg LANG=de)

I could also copy the conversion functions from here  https://github.com/ros-planning/moveit/blob/master/moveit_core/utils/src/lexical_casts.cpp (with a suitable namespace) and use them, what do you prefer?