### PR TITLE
[HACK][Camera2] init parameters

### DIFF
--- a/droidmediacamera2.cpp
+++ b/droidmediacamera2.cpp
@@ -129,6 +129,8 @@ struct _DroidMediaCamera
 
     // Requests
     ACaptureRequest *m_preview_request = NULL;
+    std::unordered_map<std::string, std::string> m_param_map;
+
     ACaptureRequest *m_image_request = NULL;
     ACaptureRequest *m_video_request = NULL;
 
@@ -864,6 +866,9 @@ bool droid_media_camera_unlock(DroidMediaCamera *camera)
     return true;
 }
 
+// Forward declaration.
+void update_request(DroidMediaCamera *camera, ACaptureRequest *request, std::unordered_map<std::string, std::string> &param_map);
+
 bool droid_media_camera_start_preview(DroidMediaCamera *camera)
 {
     ALOGI("start_preview");
@@ -875,6 +880,21 @@ bool droid_media_camera_start_preview(DroidMediaCamera *camera)
     if (!setup_capture_session(camera)) {
         ALOGE("Failed to setup capture session");
         return false;
+    }
+
+    if (camera->m_image_request) {
+        ALOGI("update_request image mode again.");
+        update_request(camera, camera->m_image_request, camera->m_param_map);
+    }
+
+    if (camera->m_video_request) {
+        ALOGI("update_request video mode again.");
+        update_request(camera, camera->m_video_request, camera->m_param_map);
+    }
+
+    if (camera->m_preview_request) {
+        ALOGI("update_request preview again.");
+        update_request(camera, camera->m_preview_request, camera->m_param_map);
     }
 
     status = ACameraCaptureSession_setRepeatingRequest(camera->m_session, &camera->m_capture_callbacks, 1,
@@ -1602,6 +1622,11 @@ bool droid_media_camera_set_parameters(DroidMediaCamera *camera, const char *par
         update_request(camera, camera->m_video_request, param_map);
     }
 
+    ALOGI("update_request preview");
+    if (!camera->m_preview_request) {
+        ALOGE("Not even preview, copy to try again later");
+        camera->m_param_map = param_map;
+    }
     if (camera->m_preview_request) {
         update_request(camera, camera->m_preview_request, param_map);
         if (camera->m_preview_enabled) {
@@ -1668,6 +1693,9 @@ char *droid_media_camera_get_parameters(DroidMediaCamera *camera)
                 }
                 params += ab + ";";
             }
+            break;
+        case ACAMERA_CONTROL_AE_EXPOSURE_COMPENSATION:
+            params += "exposure-compensation="+std::to_string(entry.data.i32[0]);
             break;
         case ACAMERA_CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES: {
             if (entry.count > 0) {


### PR DESCRIPTION
This PR is a hack as the title says.

There are two observations around current camera2 initialization that this fixes:

1. First is that the "params" are sent when nor image, video and not even preview requests are alive. So they go to /dev/null. 
The fix for this was to make a **copy** of the params and re-apply them when actual requests are alive
2. The second observation is that `exposure-compensation` is part of only **ONE** initial set of params sent from gst-droid, and not the second one. So there are at least **TWO** param updates before at least the preview request is alive, and only the first one has the exposure. The fix was to always propagate the first exposure-compensation sent until the copied params are applied at actual initialization.

I realize this is not a fix at all - it is just some info.
It does help me with 1. applying edge-mode and noisereduction initially and 2. applying the previous exposure