### PR TITLE
Add droid_media_camera_set_torch_mode.

### DIFF
--- a/droidmediacamera.cpp
+++ b/droidmediacamera.cpp
@@ -21,9 +21,21 @@
 #if ANDROID_MAJOR < 8
 #include "allocator.h"
 #endif
+#include <stdio.h>
+#include <string>
 #include <camera/Camera.h>
 #include <camera/CameraParameters.h>
 #include <android/log.h>
+#if ANDROID_MAJOR > 5 || (ANDROID_MAJOR == 5 && ANDROID_MINOR >= 1)
+#include <binder/Binder.h>
+#include <binder/IInterface.h>
+#include <binder/IServiceManager.h>
+#if ANDROID_MAJOR < 7
+#include <camera/ICameraService.h>
+#else
+#include <android/hardware/ICameraService.h>
+#endif
+#endif
 #include <utils/String8.h>
 #include <utils/Condition.h>
 #if ANDROID_MAJOR >= 8
@@ -316,6 +328,125 @@ bool droid_media_camera_get_info(DroidMediaCameraInfo *info, int camera_number)
     }
 
     return true;
+}
+
+static bool set_torch_mode_for_camera(const char *camera_id, bool enabled)
+{
+#if ANDROID_MAJOR > 5 || (ANDROID_MAJOR == 5 && ANDROID_MINOR >= 1)
+    if (!camera_id) {
+        ALOGE("No camera id specified");
+        return false;
+    }
+
+    android::sp<android::IServiceManager> service_manager = android::defaultServiceManager();
+    android::sp<android::IBinder> binder =
+            service_manager->checkService(android::String16("media.camera"));
+    if (binder == NULL) {
+        ALOGE("Camera service is not available");
+        return false;
+    }
+
+#if ANDROID_MAJOR < 7
+    android::sp<android::ICameraService> camera_service =
+            android::interface_cast<android::ICameraService>(binder);
+#else
+    android::sp<android::hardware::ICameraService> camera_service =
+            android::interface_cast<android::hardware::ICameraService>(binder);
+#endif
+    if (camera_service == NULL) {
+        ALOGE("Failed to connect to camera service");
+        return false;
+    }
+
+    static android::sp<android::IBinder> client_binder = new android::BBinder();
+#if ANDROID_MAJOR < 7
+    android::status_t status = camera_service->setTorchMode(
+            android::String16(camera_id), enabled, client_binder);
+    if (status != android::NO_ERROR) {
+        ALOGE("Failed to set torch mode for camera %s: %d", camera_id, status);
+        return false;
+    }
+#else
+#if ANDROID_MAJOR >= 15
+    android::content::AttributionSourceState clientAttribution;
+    clientAttribution.uid = android::hardware::ICameraService::USE_CALLING_UID;
+    clientAttribution.pid = android::hardware::ICameraService::USE_CALLING_PID;
+    clientAttribution.deviceId = android::kDefaultDeviceId;
+    clientAttribution.packageName = "droidmedia";
+
+    android::binder::Status status = camera_service->setTorchMode(
+            std::string(camera_id), enabled, client_binder, clientAttribution, 0);
+#else
+    android::binder::Status status = camera_service->setTorchMode(
+            android::String16(camera_id), enabled, client_binder);
+#endif
+    if (!status.isOk()) {
+        ALOGE("Failed to set torch mode for camera %s: exception %d",
+              camera_id, status.exceptionCode());
+        return false;
+    }
+#endif
+    return true;
+#else
+    (void)camera_id;
+    (void)enabled;
+    ALOGW("Camera service torch mode is not supported before Android 5.1");
+    return false;
+#endif
+}
+
+static bool set_torch_mode_by_camera_number(int camera_number, bool enabled)
+{
+    char camera_id[12];
+    snprintf(camera_id, sizeof(camera_id), "%d", camera_number);
+    return set_torch_mode_for_camera(camera_id, enabled);
+}
+
+bool droid_media_camera_set_torch_mode(bool enabled)
+{
+    static int default_torch_camera = -1;
+
+    if (!enabled) {
+        if (default_torch_camera < 0) {
+            return false;
+        }
+
+        bool success = set_torch_mode_by_camera_number(default_torch_camera, false);
+        default_torch_camera = -1;
+        return success;
+    }
+
+    if (default_torch_camera >= 0) {
+        if (set_torch_mode_by_camera_number(default_torch_camera, true)) {
+            return true;
+        }
+        default_torch_camera = -1;
+    }
+
+    int camera_count = droid_media_camera_get_number_of_cameras();
+    bool found_back_camera = false;
+
+    for (int i = 0; i < camera_count; ++i) {
+        DroidMediaCameraInfo info;
+        if (!droid_media_camera_get_info(&info, i)
+                || info.facing != DROID_MEDIA_CAMERA_FACING_BACK) {
+            continue;
+        }
+
+        found_back_camera = true;
+        if (set_torch_mode_by_camera_number(i, true)) {
+            default_torch_camera = i;
+            return true;
+        }
+    }
+
+    if (!found_back_camera && camera_count > 0
+            && set_torch_mode_by_camera_number(0, true)) {
+        default_torch_camera = 0;
+        return true;
+    }
+
+    return false;
 }
 
 DroidMediaCamera *droid_media_camera_connect(int camera_number)

--- a/droidmediacamera.h
+++ b/droidmediacamera.h
@@ -79,6 +79,7 @@ DroidMediaBufferQueue *droid_media_camera_get_buffer_queue (DroidMediaCamera *ca
 DroidMediaBufferQueue *droid_media_camera_get_recording_buffer_queue (DroidMediaCamera *camera);
 int droid_media_camera_get_number_of_cameras();
 bool droid_media_camera_get_info(DroidMediaCameraInfo *info, int camera_number);
+bool droid_media_camera_set_torch_mode(bool enabled);
 
 DroidMediaCamera *droid_media_camera_connect(int camera_number);
 bool droid_media_camera_reconnect(DroidMediaCamera *camera);

--- a/flashlight/flashlightservice.cpp
+++ b/flashlight/flashlightservice.cpp
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Jolla Mobile Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <QtDebug>
+#include <QObject>
+#include <QCoreApplication>
+#include <QTimer>
+#include <QList>
+
+#include <policy/resource-set.h>
+#include <policy/resources.h>
+#include <droidmediacamera.h>
+
+#include "flashlightservice.h"
+
+FlashlightService::FlashlightService(QObject *parent)
+    : QObject(parent),
+      m_resourceSet(nullptr),
+      m_wantedState(false), m_flashlightAvailable(true),
+      m_cameraServiceTorchActive(false), m_droidMediaInitialized(droid_media_init())
+{
+    // Resource-policy reports availability asynchronously after D-Bus activation.
+    // Allow the first request through and let acquire()/resourcesDenied() arbitrate.
+    m_resourceSet = new ResourcePolicy::ResourceSet("background", this, true, true);
+    m_resourceSet->addResource(ResourcePolicy::RearFlashlightType);
+    connect(m_resourceSet, &ResourcePolicy::ResourceSet::resourcesBecameAvailable,
+            this, &FlashlightService::resourcesAvailableHandler);
+    connect(m_resourceSet, &ResourcePolicy::ResourceSet::resourcesGranted,
+            this, &FlashlightService::resourcesAcquiredHandler);
+    connect(m_resourceSet, &ResourcePolicy::ResourceSet::resourcesDenied,
+            this, &FlashlightService::resourcesDeniedHandler);
+    connect(m_resourceSet, &ResourcePolicy::ResourceSet::lostResources,
+            this, &FlashlightService::resourcesLostHandler);
+    m_resourceSet->initAndConnect();
+
+    m_timer.setInterval(2 * 60 * 1000);
+    m_timer.setSingleShot(true);
+    connect(&m_timer, &QTimer::timeout, this, &FlashlightService::deactivate);
+    m_timer.start(); // just in case the user never turns the flashlight on.
+}
+
+FlashlightService::~FlashlightService()
+{
+    cleanup();
+}
+
+void FlashlightService::deactivate()
+{
+    bool needEmit = isFlashlightOn();
+    cleanup();
+    if (needEmit) {
+        emit flashlightOnChanged(false);
+    }
+    qApp->quit();
+}
+
+bool FlashlightService::isFlashlightOn() const
+{
+    return m_cameraServiceTorchActive;
+}
+
+void FlashlightService::cleanup()
+{
+    if (m_cameraServiceTorchActive) {
+        setCameraServiceTorch(false);
+    }
+}
+
+bool FlashlightService::setCameraServiceTorch(bool active)
+{
+    if (!m_droidMediaInitialized)
+        return false;
+
+    if (!droid_media_camera_set_torch_mode(active)) {
+        if (!active)
+            m_cameraServiceTorchActive = false;
+        return false;
+    }
+
+    m_cameraServiceTorchActive = active;
+    return true;
+}
+
+bool FlashlightService::toggleFlashlight()
+{
+    if (!m_resourceSet)
+        return false;
+
+    // If someone else has acquired the flashlight resource do not even
+    // try to turn the flashlight on.
+    if (!m_flashlightAvailable)
+        return false;
+
+    m_wantedState = !m_wantedState;
+
+    if (isFlashlightOn() == m_wantedState)
+        return false;
+
+    if (m_wantedState) {
+        // Acquire flashlight resource, and if/when granted
+        // set flaslight on.
+        m_resourceSet->acquire();
+    } else {
+        setFlashlight(false);
+        m_resourceSet->release();
+    }
+
+    return true;
+}
+
+void FlashlightService::setFlashlight(bool active)
+{
+    if (active) {
+        if (isFlashlightOn()) {
+            qWarning() << "Flashlight was already on.";
+            return;
+        }
+
+        if (setCameraServiceTorch(true)) {
+            m_timer.stop(); // stop the inactivity timer while the flashlight is on
+            emit flashlightOnChanged(true);
+            return;
+        }
+
+        qWarning() << "failed to turn on flashlight";
+        m_wantedState = false;
+        if (m_resourceSet)
+            m_resourceSet->release();
+    } else {
+        // the flashlight is on.  turn it off by destroying the active backend.
+        cleanup();
+        m_timer.start(); // start the inactivity timer
+        emit flashlightOnChanged(false);
+    }
+}
+
+void FlashlightService::resourcesAvailableHandler(const QList<ResourcePolicy::ResourceType> &available)
+{
+    m_flashlightAvailable = available.contains(ResourcePolicy::RearFlashlightType);
+}
+
+void FlashlightService::resourcesAcquiredHandler()
+{
+    setFlashlight(m_wantedState);
+}
+
+void FlashlightService::resourcesDeniedHandler()
+{
+    m_wantedState = false;
+}
+
+void FlashlightService::resourcesLostHandler()
+{
+    m_wantedState = false;
+    setFlashlight(false);
+}

--- a/flashlight/flashlightservice.h
+++ b/flashlight/flashlightservice.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Jolla Mobile Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FLASHLIGHTSERVICE_H
+#define FLASHLIGHTSERVICE_H
+
+#include <QtCore/QTimer>
+#include <QtCore/QObject>
+#include <QtDBus/QDBusContext>
+#include <QList>
+
+#include <policy/resource-set.h>
+#include <policy/resource.h>
+
+class FlashlightService : public QObject, protected QDBusContext
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.sailfish.flashlight.provider")
+    Q_PROPERTY(bool flashlightOn READ isFlashlightOn NOTIFY flashlightOnChanged)
+
+public:
+    FlashlightService(QObject *parent = 0);
+    ~FlashlightService();
+
+    bool isFlashlightOn() const;
+    Q_INVOKABLE bool toggleFlashlight();
+
+Q_SIGNALS:
+    void flashlightOnChanged(bool newOn);
+
+private Q_SLOTS:
+    void deactivate();
+    void resourcesAvailableHandler(const QList<ResourcePolicy::ResourceType> &available);
+    void resourcesAcquiredHandler();
+    void resourcesDeniedHandler();
+    void resourcesLostHandler();
+
+private:
+    void setFlashlight(bool active);
+    bool setCameraServiceTorch(bool active);
+    void cleanup();
+
+    QTimer m_timer;
+    ResourcePolicy::ResourceSet *m_resourceSet;
+    bool m_wantedState;
+    bool m_flashlightAvailable;
+    bool m_cameraServiceTorchActive;
+    bool m_droidMediaInitialized;
+};
+
+#endif // FLASHLIGHTSERVICE_H

--- a/flashlight/main.cpp
+++ b/flashlight/main.cpp
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Jolla Mobile Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flashlightservice.h"
+
+#include <QCoreApplication>
+#include <QString>
+#include <QDBusConnection>
+#include <QtDebug>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    app.setApplicationName("droidmedia-flashlight");
+
+    FlashlightService flashlightService;
+    QString serviceName = QLatin1String("org.sailfish.flashlight.provider");
+    QString objectPath = QLatin1String("/org/sailfish/flashlight/provider");
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    bool registeredObject = sessionBus.registerObject(objectPath, &flashlightService, QDBusConnection::ExportAllContents);
+    bool registeredService = sessionBus.registerService(serviceName);
+
+    int retn = 1;
+    if (!registeredService || !registeredObject) {
+        qWarning() << Q_FUNC_INFO << "CRITICAL: unable to register"
+                   << "sync service:" << serviceName
+                   << "object path:"  << objectPath;
+    } else {
+        retn = app.exec();
+    }
+
+    if (registeredService) {
+        sessionBus.unregisterService(serviceName);
+    }
+    if (registeredObject) {
+        sessionBus.unregisterObject(objectPath);
+    }
+
+    return retn;
+}

--- a/flashlight/org.sailfish.flashlight.provider.service
+++ b/flashlight/org.sailfish.flashlight.provider.service
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025-2026 Jolla Mobile Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+[D-BUS Service]
+Name=org.sailfish.flashlight.provider
+Exec=/usr/bin/droidmedia-flashlight

--- a/flashlight/org.sailfish.flashlight.provider.xml
+++ b/flashlight/org.sailfish.flashlight.provider.xml
@@ -1,0 +1,16 @@
+<!--
+ * SPDX-FileCopyrightText: 2025-2026 Jolla Mobile Ltd
+ * SPDX-License-Identifier: Apache-2.0
+-->
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.sailfish.flashlight.provider">
+        <property name="flashlightOn" type="b" access="read" />
+        <signal name="flashlightOnChanged">
+            <arg name="newOn" type="b" direction="out" />
+        </signal>
+        <method name="toggleFlashlight">
+            <arg name="available" type="b" direction="out" />
+        </method>
+    </interface>
+</node>

--- a/hybris.c
+++ b/hybris.c
@@ -81,6 +81,15 @@ static inline void *__resolve_sym(const char *sym)
   return ptr;
 }
 
+static inline void *__try_resolve_sym(const char *sym)
+{
+  if (!__handle) {
+    __load_library();
+  }
+
+  return _android_dlsym(__handle, sym);
+}
+
 #define HYBRIS_WRAPPER_1_0(ret,sym)		    \
   ret sym() {					    \
     static ret (* _sym)() = NULL;		    \
@@ -261,6 +270,19 @@ HYBRIS_WRAPPER_0_1(DroidMediaRecorder*,droid_media_recorder_destroy);
 HYBRIS_WRAPPER_1_1(bool,DroidMediaRecorder*,droid_media_recorder_start);
 HYBRIS_WRAPPER_0_1(DroidMediaRecorder*,droid_media_recorder_stop);
 HYBRIS_WRAPPER_0_3(DroidMediaRecorder*,DroidMediaCodecDataCallbacks*,void*,droid_media_recorder_set_data_callbacks);
+
+bool droid_media_camera_set_torch_mode(bool enabled)
+{
+  static bool (* _sym)(bool) = NULL;
+  static bool attempted = false;
+
+  if (!attempted) {
+    _sym = __try_resolve_sym("droid_media_camera_set_torch_mode");
+    attempted = true;
+  }
+
+  return _sym ? _sym(enabled) : false;
+}
 
 bool droid_media_init(void)
 {

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'droidmedia', 'c',
+  'droidmedia', ['c', 'cpp'],
   default_options : ['warning_level=1', 'buildtype=debugoptimized'],
 )
 
@@ -7,6 +7,7 @@ droidmedia_version = meson.project_version()
 droidmedia = meson.project_name()
 
 cc = meson.get_compiler('c')
+dl_dep = cc.find_library('dl', required : true)
 
 root_dir = include_directories('.')
 
@@ -17,7 +18,7 @@ droidmedia_source = [
 libdroidmedia_a = static_library('droidmedia',
                                  droidmedia_source,
                                  install: true,
-                                 dependencies: cc.find_library('dl', required : true))
+                                 dependencies: dl_dep)
 
 droidmedia_headers = [
     'droidmediacamera.h',
@@ -30,6 +31,42 @@ droidmedia_headers = [
 
 install_headers(droidmedia_headers, subdir : meson.project_name())
 install_data('hybris.c', install_dir : get_option('datadir') / meson.project_name())
+
+qt5 = import('qt5')
+
+flashlight_qt_deps = [
+  dependency('Qt5Core'),
+  dependency('Qt5DBus'),
+]
+
+flashlight_deps = flashlight_qt_deps + [
+  dependency('libresourceqt5', version : '>=1.29'),
+  dl_dep,
+]
+
+flashlight_moc = qt5.preprocess(
+  moc_headers : ['flashlight/flashlightservice.h'],
+  dependencies : flashlight_qt_deps,
+)
+
+executable(
+  'droidmedia-flashlight',
+  [
+    'flashlight/main.cpp',
+    'flashlight/flashlightservice.cpp',
+    flashlight_moc,
+  ],
+  include_directories : root_dir,
+  dependencies : flashlight_deps,
+  link_with : libdroidmedia_a,
+  install : true,
+  install_dir : get_option('bindir'),
+)
+
+install_data(
+  'flashlight/org.sailfish.flashlight.provider.service',
+  install_dir : get_option('datadir') / 'dbus-1' / 'services',
+)
 
 pkg = import('pkgconfig')
 pkg.generate(libdroidmedia_a,

--- a/rpm/droidmedia-devel.spec
+++ b/rpm/droidmedia-devel.spec
@@ -6,11 +6,22 @@ License:       ASL 2.0
 Source0:       %{name}-%{version}.tgz
 BuildRequires: meson
 BuildRequires: ninja
+BuildRequires: pkgconfig(Qt5Core)
+BuildRequires: pkgconfig(Qt5DBus)
+BuildRequires: pkgconfig(libresourceqt5) >= 1.29
 Suggests:      libhybris
 Suggests:      droidmedia = %{version}-%{release}
 
 %description
 %{summary}
+
+%package -n droidmedia-flashlight
+Summary:       Android-backed flashlight D-Bus service
+Requires:      droidmedia
+Provides:      sailfish-flashlight-provider
+
+%description -n droidmedia-flashlight
+Android-backed implementation of the Jolla settings flashlight D-Bus service.
 
 %prep
 %setup -q
@@ -24,8 +35,11 @@ meson rewrite kwargs set project / version %{version}
 %meson_install
 
 %files
-%defattr(-,root,root,-)
 %{_libdir}/libdroidmedia.a
 %{_includedir}/droidmedia/*.h
 %{_datadir}/droidmedia/hybris.c
 %{_libdir}/pkgconfig/droidmedia.pc
+
+%files -n droidmedia-flashlight
+%{_bindir}/droidmedia-flashlight
+%{_datadir}/dbus-1/services/org.sailfish.flashlight.provider.service


### PR DESCRIPTION
Add new function to directly turn the torch on instead of having to start a camera. Should be faster.

Not supported in Android < 5.1, so returns false in that case and the old method can be used. Add a __try_resolve_sym to fallback for devices with older droidmedia builds too.