### PR TITLE
Report decoder output stride/slice_height via get_output_info

### DIFF
--- a/droidmediacodec.cpp
+++ b/droidmediacodec.cpp
@@ -1162,6 +1162,11 @@ void droid_media_codec_get_output_info(DroidMediaCodec *codec,
   md->findInt32(android::kKeySampleRate, &info->sample_rate);
   md->findInt32(android::kKeyColorFormat, &info->hal_format);
 
+  info->stride = -1;
+  info->slice_height = -1;
+  md->findInt32(android::kKeyStride, &info->stride);
+  md->findInt32(android::kKeySliceHeight, &info->slice_height);
+
   if (!md->findRect(android::kKeyCropRect, &crop->left, &crop->top, &crop->right, &crop->bottom)) {
     crop->left = crop->top = 0;
     crop->right = info->width;

--- a/droidmediacodec.h
+++ b/droidmediacodec.h
@@ -59,6 +59,8 @@ typedef struct {
   int32_t sample_rate;
   int32_t hal_format;
   DroidMediaCodecFlags flags;
+  int32_t stride;
+  int32_t slice_height;
 } DroidMediaCodecMetaData;
 
 typedef struct {


### PR DESCRIPTION
For the raw (non-gralloc) decoder data path, gst-droid has to guess the row stride and padded slice height of the output buffer using hardcoded per-colour-format alignment constants, since droid_media_codec_get_output_info never exposed the values the underlying codec actually used. When a device's decoder output doesn't match the guessed alignment, gst-droid reads/writes out of bounds.

stagefright already surfaces kKeyStride/kKeySliceHeight in the codec's output format when available; forward them through DroidMediaCodecMetaData so consumers no longer have to guess.

Have in mind the fix has been written by LLM as has been above message. This fixes crash in gst-droid when using qmlglsink. 

Corresponding gst-droid fix https://github.com/sailfishos/gst-droid/pull/87

```
(gdb) bt
#0  gst_droidvec_copy_packed_planes (height=540, width=960, stride_in=1920, in=0x7f7e206d90 "", stride_out=960, out1=0x7f7c5a7c58 "", out0=0x7f7c529358 "") at ../gst/droidcodec/gstdroidvdec.c:126
#1  gst_droidvdec_convert_yuv420_packed_semi_planar_to_i420 (dec=<optimized out>, out=0x7f7eb83648, in=<optimized out>, info=0x7f64000e98, width=<optimized out>, height=<optimized out>) at ../gst/droidcodec/gstdroidvdec.c:271
#2  0x0000007ff0cc0488 in gst_droidvdec_convert_buffer (info=0x7f64000e98, in=0x7f7eb836b8, out=0x7f6400c0e0, dec=0x7fc40a6df0 [GstDroidVDec]) at ../gst/droidcodec/gstdroidvdec.c:457
#3  gst_droidvdec_data_available (data=0x7fc40a6df0, encoded=0x7f7eb836b8) at ../gst/droidcodec/gstdroidvdec.c:608
#4  0x0000007fae1308cc in  ()
#5  0x0000007fc40a6df0 in  ()
#6  0x0000007fc40a48e0 in  ()
```